### PR TITLE
[Config][Backend] Spring Boot 기본 프로젝트 구조 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.13'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.tunesharehub'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+ext {
+    jjwtVersion = '0.12.6'
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
+    implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
+
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
+    runtimeOnly 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'tune-share-hub'

--- a/src/main/java/com/tunesharehub/TuneShareHubApplication.java
+++ b/src/main/java/com/tunesharehub/TuneShareHubApplication.java
@@ -1,0 +1,12 @@
+package com.tunesharehub;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TuneShareHubApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TuneShareHubApplication.class, args);
+    }
+}

--- a/src/main/java/com/tunesharehub/auth/package-info.java
+++ b/src/main/java/com/tunesharehub/auth/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.auth;

--- a/src/main/java/com/tunesharehub/config/package-info.java
+++ b/src/main/java/com/tunesharehub/config/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.config;

--- a/src/main/java/com/tunesharehub/controller/package-info.java
+++ b/src/main/java/com/tunesharehub/controller/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.controller;

--- a/src/main/java/com/tunesharehub/dto/package-info.java
+++ b/src/main/java/com/tunesharehub/dto/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.dto;

--- a/src/main/java/com/tunesharehub/entity/package-info.java
+++ b/src/main/java/com/tunesharehub/entity/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.entity;

--- a/src/main/java/com/tunesharehub/exception/package-info.java
+++ b/src/main/java/com/tunesharehub/exception/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.exception;

--- a/src/main/java/com/tunesharehub/mapper/package-info.java
+++ b/src/main/java/com/tunesharehub/mapper/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.mapper;

--- a/src/main/java/com/tunesharehub/service/package-info.java
+++ b/src/main/java/com/tunesharehub/service/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.service;

--- a/src/main/java/com/tunesharehub/spotify/package-info.java
+++ b/src/main/java/com/tunesharehub/spotify/package-info.java
@@ -1,0 +1,1 @@
+package com.tunesharehub.spotify;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  application:
+    name: tune-share-hub
+  datasource:
+    driver-class-name: oracle.jdbc.OracleDriver
+    url: ${DB_URL:jdbc:oracle:thin:@localhost:1521/XEPDB1}
+    username: ${DB_USERNAME:tune_share}
+    password: ${DB_PASSWORD:change-me}
+
+mybatis:
+  mapper-locations: classpath:mappers/**/*.xml
+  type-aliases-package: com.tunesharehub.entity
+  configuration:
+    map-underscore-to-camel-case: true
+
+jwt:
+  secret: ${JWT_SECRET:change-me-change-me-change-me-change-me}
+  access-token-expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION_MINUTES:60}
+  refresh-token-expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION_DAYS:14}
+
+spotify:
+  client-id: ${SPOTIFY_CLIENT_ID:}
+  client-secret: ${SPOTIFY_CLIENT_SECRET:}
+  token-url: https://accounts.spotify.com/api/token
+  api-base-url: https://api.spotify.com/v1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ mybatis:
     map-underscore-to-camel-case: true
 
 jwt:
-  secret: ${JWT_SECRET:change-me-change-me-change-me-change-me}
+  secret: ${JWT_SECRET:local-dev-secret-9f4c8e2a7b6d41c0a35e92f18d7b64aa}
   access-token-expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION_MINUTES:60}
   refresh-token-expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION_DAYS:14}
 

--- a/src/test/java/com/tunesharehub/TuneShareHubApplicationTests.java
+++ b/src/test/java/com/tunesharehub/TuneShareHubApplicationTests.java
@@ -2,11 +2,10 @@ package com.tunesharehub;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = {
-        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,"
-                + "org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration"
-})
+@ActiveProfiles("test")
+@SpringBootTest
 class TuneShareHubApplicationTests {
 
     @Test

--- a/src/test/java/com/tunesharehub/TuneShareHubApplicationTests.java
+++ b/src/test/java/com/tunesharehub/TuneShareHubApplicationTests.java
@@ -1,0 +1,15 @@
+package com.tunesharehub;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,"
+                + "org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration"
+})
+class TuneShareHubApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:tune_share_hub;MODE=Oracle;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:


### PR DESCRIPTION
## 작업 내용
- Gradle 기반 Spring Boot 프로젝트 설정 추가
- 기본 애플리케이션 클래스 추가
- controller, service, mapper, dto, entity, exception, config, auth, spotify 패키지 구조 추가
- Oracle/MyBatis/JWT/Spotify 설정을 application.yml에 환경변수 기반으로 추가
- 기본 컨텍스트 로딩 테스트 추가

## 확인
- git diff --check 통과
- 로컬에 Gradle/Maven이 없어 실제 빌드는 미수행

Closes #3