### PR TITLE
[Playlist][Backend] 플레이리스트 CRUD API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/controller/PlaylistController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistController.java
@@ -1,0 +1,83 @@
+package com.tunesharehub.controller;
+
+import com.tunesharehub.auth.AuthUser;
+import com.tunesharehub.auth.CurrentUser;
+import com.tunesharehub.dto.PlaylistCreateRequest;
+import com.tunesharehub.dto.PlaylistResponse;
+import com.tunesharehub.dto.PlaylistUpdateRequest;
+import com.tunesharehub.service.PlaylistService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api")
+public class PlaylistController {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+
+    private final PlaylistService playlistService;
+
+    public PlaylistController(PlaylistService playlistService) {
+        this.playlistService = playlistService;
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/playlists")
+    public PlaylistResponse createPlaylist(
+            @CurrentUser AuthUser authUser,
+            @Valid @RequestBody PlaylistCreateRequest request
+    ) {
+        return playlistService.createPlaylist(authUser.userId(), request);
+    }
+
+    @GetMapping("/playlists/{playlistId}")
+    public PlaylistResponse getPlaylist(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId
+    ) {
+        return playlistService.getPlaylist(authUser.userId(), playlistId);
+    }
+
+    @GetMapping("/me/playlists")
+    public List<PlaylistResponse> getMyPlaylists(
+            @CurrentUser AuthUser authUser,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
+    ) {
+        return playlistService.getMyPlaylists(authUser.userId(), page, size);
+    }
+
+    @PutMapping("/playlists/{playlistId}")
+    public PlaylistResponse updatePlaylist(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId,
+            @Valid @RequestBody PlaylistUpdateRequest request
+    ) {
+        return playlistService.updatePlaylist(authUser.userId(), playlistId, request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/playlists/{playlistId}")
+    public void deletePlaylist(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId
+    ) {
+        playlistService.deletePlaylist(authUser.userId(), playlistId);
+    }
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistCreateRequest.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistCreateRequest.java
@@ -1,0 +1,18 @@
+package com.tunesharehub.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PlaylistCreateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        String description,
+
+        @Size(max = 1000)
+        String coverImageUrl,
+
+        Boolean publicYn
+) {
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistResponse.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistResponse.java
@@ -1,0 +1,19 @@
+package com.tunesharehub.dto;
+
+import java.time.LocalDateTime;
+
+public record PlaylistResponse(
+        Long playlistId,
+        Long userId,
+        String userNickname,
+        String title,
+        String description,
+        String coverImageUrl,
+        Boolean publicYn,
+        Long viewCount,
+        Long likeCount,
+        Long commentCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistUpdateRequest.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.tunesharehub.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PlaylistUpdateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String title,
+
+        String description,
+
+        @Size(max = 1000)
+        String coverImageUrl,
+
+        Boolean publicYn
+) {
+}

--- a/src/main/java/com/tunesharehub/entity/Playlist.java
+++ b/src/main/java/com/tunesharehub/entity/Playlist.java
@@ -1,0 +1,124 @@
+package com.tunesharehub.entity;
+
+import java.time.LocalDateTime;
+
+public class Playlist {
+
+    private Long playlistId;
+    private Long userId;
+    private String userNickname;
+    private String title;
+    private String description;
+    private String coverImageUrl;
+    private String publicYn;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public Long getPlaylistId() {
+        return playlistId;
+    }
+
+    public void setPlaylistId(Long playlistId) {
+        this.playlistId = playlistId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUserNickname() {
+        return userNickname;
+    }
+
+    public void setUserNickname(String userNickname) {
+        this.userNickname = userNickname;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCoverImageUrl() {
+        return coverImageUrl;
+    }
+
+    public void setCoverImageUrl(String coverImageUrl) {
+        this.coverImageUrl = coverImageUrl;
+    }
+
+    public String getPublicYn() {
+        return publicYn;
+    }
+
+    public void setPublicYn(String publicYn) {
+        this.publicYn = publicYn;
+    }
+
+    public Long getViewCount() {
+        return viewCount;
+    }
+
+    public void setViewCount(Long viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public Long getLikeCount() {
+        return likeCount;
+    }
+
+    public void setLikeCount(Long likeCount) {
+        this.likeCount = likeCount;
+    }
+
+    public Long getCommentCount() {
+        return commentCount;
+    }
+
+    public void setCommentCount(Long commentCount) {
+        this.commentCount = commentCount;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+}

--- a/src/main/java/com/tunesharehub/exception/ForbiddenException.java
+++ b/src/main/java/com/tunesharehub/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.tunesharehub.exception;
+
+public class ForbiddenException extends BusinessException {
+
+    public ForbiddenException(String message) {
+        super("FORBIDDEN", message);
+    }
+}

--- a/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.tunesharehub.exception;
 import com.tunesharehub.auth.InvalidTokenException;
 import com.tunesharehub.auth.UnauthorizedException;
 import com.tunesharehub.dto.ErrorResponse;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -30,6 +31,18 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(ForbiddenException exception) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(PlaylistNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePlaylistNotFound(PlaylistNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
+    }
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -38,6 +51,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException() {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse("INVALID_REQUEST", "요청 값이 올바르지 않습니다."));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException() {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse("INVALID_REQUEST", "요청 값이 올바르지 않습니다."));
     }

--- a/src/main/java/com/tunesharehub/exception/PlaylistNotFoundException.java
+++ b/src/main/java/com/tunesharehub/exception/PlaylistNotFoundException.java
@@ -1,0 +1,8 @@
+package com.tunesharehub.exception;
+
+public class PlaylistNotFoundException extends BusinessException {
+
+    public PlaylistNotFoundException() {
+        super("PLAYLIST_NOT_FOUND", "플레이리스트를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
@@ -1,0 +1,33 @@
+package com.tunesharehub.mapper;
+
+import com.tunesharehub.entity.Playlist;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PlaylistMapper {
+
+    void insert(Playlist playlist);
+
+    Playlist findById(@Param("playlistId") Long playlistId);
+
+    List<Playlist> findByUserId(
+            @Param("userId") Long userId,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
+    int updateOwned(Playlist playlist);
+
+    int softDeleteOwned(
+            @Param("playlistId") Long playlistId,
+            @Param("userId") Long userId
+    );
+
+    void softDeleteTracksByPlaylistId(@Param("playlistId") Long playlistId);
+
+    void softDeleteCommentsByPlaylistId(@Param("playlistId") Long playlistId);
+
+    void softDeleteLikesByPlaylistId(@Param("playlistId") Long playlistId);
+}

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -1,0 +1,134 @@
+package com.tunesharehub.service;
+
+import com.tunesharehub.dto.PlaylistCreateRequest;
+import com.tunesharehub.dto.PlaylistResponse;
+import com.tunesharehub.dto.PlaylistUpdateRequest;
+import com.tunesharehub.entity.Playlist;
+import com.tunesharehub.exception.ForbiddenException;
+import com.tunesharehub.exception.PlaylistNotFoundException;
+import com.tunesharehub.mapper.PlaylistMapper;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PlaylistService {
+
+    private static final String PUBLIC_YN_TRUE = "Y";
+    private static final String PUBLIC_YN_FALSE = "N";
+
+    private final PlaylistMapper playlistMapper;
+
+    public PlaylistService(PlaylistMapper playlistMapper) {
+        this.playlistMapper = playlistMapper;
+    }
+
+    @Transactional
+    public PlaylistResponse createPlaylist(Long userId, PlaylistCreateRequest request) {
+        Playlist playlist = new Playlist();
+        playlist.setUserId(userId);
+        playlist.setTitle(request.title());
+        playlist.setDescription(request.description());
+        playlist.setCoverImageUrl(request.coverImageUrl());
+        playlist.setPublicYn(toYn(request.publicYn()));
+
+        playlistMapper.insert(playlist);
+        return getPlaylist(userId, playlist.getPlaylistId());
+    }
+
+    @Transactional(readOnly = true)
+    public PlaylistResponse getPlaylist(Long loginUserId, Long playlistId) {
+        Playlist playlist = getExistingPlaylist(playlistId);
+        validateReadable(loginUserId, playlist);
+        return toResponse(playlist);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaylistResponse> getMyPlaylists(Long userId, int page, int size) {
+        int offset = page * size;
+        return playlistMapper.findByUserId(userId, offset, size)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public PlaylistResponse updatePlaylist(Long userId, Long playlistId, PlaylistUpdateRequest request) {
+        Playlist playlist = getExistingPlaylist(playlistId);
+        validateOwner(userId, playlist);
+
+        playlist.setTitle(request.title());
+        playlist.setDescription(request.description());
+        playlist.setCoverImageUrl(request.coverImageUrl());
+        if (request.publicYn() != null) {
+            playlist.setPublicYn(toYn(request.publicYn()));
+        }
+
+        int updatedCount = playlistMapper.updateOwned(playlist);
+        if (updatedCount != 1) {
+            throw new PlaylistNotFoundException();
+        }
+
+        return getPlaylist(userId, playlistId);
+    }
+
+    @Transactional
+    public void deletePlaylist(Long userId, Long playlistId) {
+        Playlist playlist = getExistingPlaylist(playlistId);
+        validateOwner(userId, playlist);
+
+        int deletedCount = playlistMapper.softDeleteOwned(playlistId, userId);
+        if (deletedCount != 1) {
+            throw new PlaylistNotFoundException();
+        }
+
+        playlistMapper.softDeleteTracksByPlaylistId(playlistId);
+        playlistMapper.softDeleteCommentsByPlaylistId(playlistId);
+        playlistMapper.softDeleteLikesByPlaylistId(playlistId);
+    }
+
+    private Playlist getExistingPlaylist(Long playlistId) {
+        Playlist playlist = playlistMapper.findById(playlistId);
+        if (playlist == null) {
+            throw new PlaylistNotFoundException();
+        }
+        return playlist;
+    }
+
+    private void validateReadable(Long loginUserId, Playlist playlist) {
+        if (PUBLIC_YN_TRUE.equals(playlist.getPublicYn()) || playlist.getUserId().equals(loginUserId)) {
+            return;
+        }
+        throw new ForbiddenException("비공개 플레이리스트에 접근할 수 없습니다.");
+    }
+
+    private void validateOwner(Long userId, Playlist playlist) {
+        if (!playlist.getUserId().equals(userId)) {
+            throw new ForbiddenException("플레이리스트 작성자만 변경할 수 있습니다.");
+        }
+    }
+
+    private PlaylistResponse toResponse(Playlist playlist) {
+        return new PlaylistResponse(
+                playlist.getPlaylistId(),
+                playlist.getUserId(),
+                playlist.getUserNickname(),
+                playlist.getTitle(),
+                playlist.getDescription(),
+                playlist.getCoverImageUrl(),
+                PUBLIC_YN_TRUE.equals(playlist.getPublicYn()),
+                playlist.getViewCount(),
+                playlist.getLikeCount(),
+                playlist.getCommentCount(),
+                playlist.getCreatedAt(),
+                playlist.getUpdatedAt()
+        );
+    }
+
+    private String toYn(Boolean value) {
+        if (value == null || value) {
+            return PUBLIC_YN_TRUE;
+        }
+        return PUBLIC_YN_FALSE;
+    }
+}

--- a/src/main/resources/mappers/PlaylistMapper.xml
+++ b/src/main/resources/mappers/PlaylistMapper.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.tunesharehub.mapper.PlaylistMapper">
+
+    <insert id="insert" parameterType="com.tunesharehub.entity.Playlist">
+        <selectKey keyProperty="playlistId" resultType="long" order="BEFORE">
+            SELECT SEQ_PLAYLISTS.NEXTVAL FROM DUAL
+        </selectKey>
+        INSERT INTO PLAYLISTS (
+            PLAYLIST_ID,
+            USER_ID,
+            TITLE,
+            DESCRIPTION,
+            COVER_IMAGE_URL,
+            PUBLIC_YN
+        ) VALUES (
+            #{playlistId},
+            #{userId},
+            #{title},
+            #{description, jdbcType=CLOB},
+            #{coverImageUrl, jdbcType=VARCHAR},
+            #{publicYn}
+        )
+    </insert>
+
+    <select id="findById" resultType="com.tunesharehub.entity.Playlist">
+        SELECT
+            P.PLAYLIST_ID,
+            P.USER_ID,
+            U.NICKNAME AS USER_NICKNAME,
+            P.TITLE,
+            P.DESCRIPTION,
+            P.COVER_IMAGE_URL,
+            P.PUBLIC_YN,
+            P.VIEW_COUNT,
+            P.LIKE_COUNT,
+            P.COMMENT_COUNT,
+            P.CREATED_AT,
+            P.UPDATED_AT,
+            P.DELETED_AT
+        FROM PLAYLISTS P
+        JOIN USERS U ON U.USER_ID = P.USER_ID
+        WHERE P.PLAYLIST_ID = #{playlistId}
+          AND P.DELETED_AT IS NULL
+          AND U.DELETED_AT IS NULL
+    </select>
+
+    <select id="findByUserId" resultType="com.tunesharehub.entity.Playlist">
+        SELECT
+            P.PLAYLIST_ID,
+            P.USER_ID,
+            U.NICKNAME AS USER_NICKNAME,
+            P.TITLE,
+            P.DESCRIPTION,
+            P.COVER_IMAGE_URL,
+            P.PUBLIC_YN,
+            P.VIEW_COUNT,
+            P.LIKE_COUNT,
+            P.COMMENT_COUNT,
+            P.CREATED_AT,
+            P.UPDATED_AT,
+            P.DELETED_AT
+        FROM PLAYLISTS P
+        JOIN USERS U ON U.USER_ID = P.USER_ID
+        WHERE P.USER_ID = #{userId}
+          AND P.DELETED_AT IS NULL
+          AND U.DELETED_AT IS NULL
+        ORDER BY P.CREATED_AT DESC, P.PLAYLIST_ID DESC
+        OFFSET #{offset} ROWS FETCH NEXT #{size} ROWS ONLY
+    </select>
+
+    <update id="updateOwned" parameterType="com.tunesharehub.entity.Playlist">
+        UPDATE PLAYLISTS
+        SET
+            TITLE = #{title},
+            DESCRIPTION = #{description, jdbcType=CLOB},
+            COVER_IMAGE_URL = #{coverImageUrl, jdbcType=VARCHAR},
+            PUBLIC_YN = #{publicYn},
+            UPDATED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND USER_ID = #{userId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <update id="softDeleteOwned">
+        UPDATE PLAYLISTS
+        SET
+            DELETED_AT = SYSTIMESTAMP,
+            UPDATED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND USER_ID = #{userId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <update id="softDeleteTracksByPlaylistId">
+        UPDATE PLAYLIST_TRACKS
+        SET DELETED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <update id="softDeleteCommentsByPlaylistId">
+        UPDATE COMMENTS
+        SET
+            DELETED_AT = SYSTIMESTAMP,
+            UPDATED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <update id="softDeleteLikesByPlaylistId">
+        UPDATE PLAYLIST_LIKES
+        SET DELETED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 작업 내용

- 인증 사용자 기반 플레이리스트 생성 API 추가
- 플레이리스트 상세 조회 API 추가
- 내 플레이리스트 목록 조회 API 추가
- 플레이리스트 수정 API 추가
- 플레이리스트 soft delete API 추가
- Playlist DTO, Entity, Service, Mapper/XML 추가
- 작성자 권한 검사와 403/404 예외 응답 추가

## API

- POST /api/playlists
- GET /api/playlists/{playlistId}
- GET /api/me/playlists?page=&size=
- PUT /api/playlists/{playlistId}
- DELETE /api/playlists/{playlistId}

## 검증

- ./gradlew test
- git diff --check

Closes #6