### PR TITLE
[Track][Backend] 플레이리스트 트랙 관리 API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
@@ -1,0 +1,68 @@
+package com.tunesharehub.controller;
+
+import com.tunesharehub.auth.AuthUser;
+import com.tunesharehub.auth.CurrentUser;
+import com.tunesharehub.dto.PlaylistTrackCreateRequest;
+import com.tunesharehub.dto.PlaylistTrackReorderRequest;
+import com.tunesharehub.dto.PlaylistTrackResponse;
+import com.tunesharehub.service.PlaylistTrackService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/playlists/{playlistId}/tracks")
+public class PlaylistTrackController {
+
+    private final PlaylistTrackService playlistTrackService;
+
+    public PlaylistTrackController(PlaylistTrackService playlistTrackService) {
+        this.playlistTrackService = playlistTrackService;
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public PlaylistTrackResponse addTrack(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId,
+            @Valid @RequestBody PlaylistTrackCreateRequest request
+    ) {
+        return playlistTrackService.addTrack(authUser.userId(), playlistId, request);
+    }
+
+    @GetMapping
+    public List<PlaylistTrackResponse> getTracks(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId
+    ) {
+        return playlistTrackService.getTracks(authUser.userId(), playlistId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{playlistTrackId}")
+    public void deleteTrack(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId,
+            @PathVariable Long playlistTrackId
+    ) {
+        playlistTrackService.deleteTrack(authUser.userId(), playlistId, playlistTrackId);
+    }
+
+    @PutMapping("/positions")
+    public List<PlaylistTrackResponse> reorderTracks(
+            @CurrentUser AuthUser authUser,
+            @PathVariable Long playlistId,
+            @Valid @RequestBody PlaylistTrackReorderRequest request
+    ) {
+        return playlistTrackService.reorderTracks(authUser.userId(), playlistId, request);
+    }
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistTrackCreateRequest.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistTrackCreateRequest.java
@@ -1,0 +1,34 @@
+package com.tunesharehub.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PlaylistTrackCreateRequest(
+        @NotBlank
+        @Size(max = 100)
+        String spotifyTrackId,
+
+        @NotBlank
+        @Size(max = 255)
+        String title,
+
+        @NotBlank
+        @Size(max = 255)
+        String artistName,
+
+        @Size(max = 255)
+        String albumName,
+
+        @Size(max = 1000)
+        String albumImageUrl,
+
+        @NotBlank
+        @Size(max = 1000)
+        String spotifyUrl,
+
+        @Size(max = 1000)
+        String previewUrl,
+
+        Long durationMs
+) {
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistTrackReorderRequest.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistTrackReorderRequest.java
@@ -1,0 +1,10 @@
+package com.tunesharehub.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record PlaylistTrackReorderRequest(
+        @NotEmpty
+        List<Long> playlistTrackIds
+) {
+}

--- a/src/main/java/com/tunesharehub/dto/PlaylistTrackResponse.java
+++ b/src/main/java/com/tunesharehub/dto/PlaylistTrackResponse.java
@@ -1,0 +1,19 @@
+package com.tunesharehub.dto;
+
+import java.time.LocalDateTime;
+
+public record PlaylistTrackResponse(
+        Long playlistTrackId,
+        Long playlistId,
+        String spotifyTrackId,
+        String title,
+        String artistName,
+        String albumName,
+        String albumImageUrl,
+        String spotifyUrl,
+        String previewUrl,
+        Long durationMs,
+        Long positionNo,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/tunesharehub/entity/PlaylistTrack.java
+++ b/src/main/java/com/tunesharehub/entity/PlaylistTrack.java
@@ -1,0 +1,124 @@
+package com.tunesharehub.entity;
+
+import java.time.LocalDateTime;
+
+public class PlaylistTrack {
+
+    private Long playlistTrackId;
+    private Long playlistId;
+    private String spotifyTrackId;
+    private String title;
+    private String artistName;
+    private String albumName;
+    private String albumImageUrl;
+    private String spotifyUrl;
+    private String previewUrl;
+    private Long durationMs;
+    private Long positionNo;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+
+    public Long getPlaylistTrackId() {
+        return playlistTrackId;
+    }
+
+    public void setPlaylistTrackId(Long playlistTrackId) {
+        this.playlistTrackId = playlistTrackId;
+    }
+
+    public Long getPlaylistId() {
+        return playlistId;
+    }
+
+    public void setPlaylistId(Long playlistId) {
+        this.playlistId = playlistId;
+    }
+
+    public String getSpotifyTrackId() {
+        return spotifyTrackId;
+    }
+
+    public void setSpotifyTrackId(String spotifyTrackId) {
+        this.spotifyTrackId = spotifyTrackId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getArtistName() {
+        return artistName;
+    }
+
+    public void setArtistName(String artistName) {
+        this.artistName = artistName;
+    }
+
+    public String getAlbumName() {
+        return albumName;
+    }
+
+    public void setAlbumName(String albumName) {
+        this.albumName = albumName;
+    }
+
+    public String getAlbumImageUrl() {
+        return albumImageUrl;
+    }
+
+    public void setAlbumImageUrl(String albumImageUrl) {
+        this.albumImageUrl = albumImageUrl;
+    }
+
+    public String getSpotifyUrl() {
+        return spotifyUrl;
+    }
+
+    public void setSpotifyUrl(String spotifyUrl) {
+        this.spotifyUrl = spotifyUrl;
+    }
+
+    public String getPreviewUrl() {
+        return previewUrl;
+    }
+
+    public void setPreviewUrl(String previewUrl) {
+        this.previewUrl = previewUrl;
+    }
+
+    public Long getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(Long durationMs) {
+        this.durationMs = durationMs;
+    }
+
+    public Long getPositionNo() {
+        return positionNo;
+    }
+
+    public void setPositionNo(Long positionNo) {
+        this.positionNo = positionNo;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+}

--- a/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
@@ -43,6 +43,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
     }
 
+    @ExceptionHandler(PlaylistTrackNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePlaylistTrackNotFound(PlaylistTrackNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
+    }
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/tunesharehub/exception/PlaylistTrackNotFoundException.java
+++ b/src/main/java/com/tunesharehub/exception/PlaylistTrackNotFoundException.java
@@ -1,0 +1,8 @@
+package com.tunesharehub.exception;
+
+public class PlaylistTrackNotFoundException extends BusinessException {
+
+    public PlaylistTrackNotFoundException() {
+        super("PLAYLIST_TRACK_NOT_FOUND", "플레이리스트 트랙을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
@@ -12,6 +12,8 @@ public interface PlaylistMapper {
 
     Playlist findById(@Param("playlistId") Long playlistId);
 
+    Playlist findByIdForUpdate(@Param("playlistId") Long playlistId);
+
     List<Playlist> findByUserId(
             @Param("userId") Long userId,
             @Param("offset") int offset,

--- a/src/main/java/com/tunesharehub/mapper/PlaylistTrackMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistTrackMapper.java
@@ -1,0 +1,38 @@
+package com.tunesharehub.mapper;
+
+import com.tunesharehub.entity.PlaylistTrack;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PlaylistTrackMapper {
+
+    void insert(PlaylistTrack playlistTrack);
+
+    PlaylistTrack findById(
+            @Param("playlistId") Long playlistId,
+            @Param("playlistTrackId") Long playlistTrackId
+    );
+
+    List<PlaylistTrack> findByPlaylistId(@Param("playlistId") Long playlistId);
+
+    int softDelete(
+            @Param("playlistId") Long playlistId,
+            @Param("playlistTrackId") Long playlistTrackId
+    );
+
+    int countActiveByIds(
+            @Param("playlistId") Long playlistId,
+            @Param("playlistTrackIds") List<Long> playlistTrackIds
+    );
+
+    int countActiveByPlaylistId(@Param("playlistId") Long playlistId);
+
+    void moveActiveTracksToTemporaryPositions(@Param("playlistId") Long playlistId);
+
+    void updatePositions(
+            @Param("playlistId") Long playlistId,
+            @Param("playlistTrackIds") List<Long> playlistTrackIds
+    );
+}

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -108,6 +108,21 @@ public class PlaylistService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public void validateOwner(Long userId, Long playlistId) {
+        Playlist playlist = getExistingPlaylist(playlistId);
+        validateOwner(userId, playlist);
+    }
+
+    @Transactional
+    public void validateOwnerForUpdate(Long userId, Long playlistId) {
+        Playlist playlist = playlistMapper.findByIdForUpdate(playlistId);
+        if (playlist == null) {
+            throw new PlaylistNotFoundException();
+        }
+        validateOwner(userId, playlist);
+    }
+
     private PlaylistResponse toResponse(Playlist playlist) {
         return new PlaylistResponse(
                 playlist.getPlaylistId(),

--- a/src/main/java/com/tunesharehub/service/PlaylistTrackService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistTrackService.java
@@ -1,0 +1,117 @@
+package com.tunesharehub.service;
+
+import com.tunesharehub.dto.PlaylistTrackCreateRequest;
+import com.tunesharehub.dto.PlaylistTrackReorderRequest;
+import com.tunesharehub.dto.PlaylistTrackResponse;
+import com.tunesharehub.entity.PlaylistTrack;
+import com.tunesharehub.exception.PlaylistTrackNotFoundException;
+import com.tunesharehub.mapper.PlaylistTrackMapper;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PlaylistTrackService {
+
+    private final PlaylistService playlistService;
+    private final PlaylistTrackMapper playlistTrackMapper;
+
+    public PlaylistTrackService(PlaylistService playlistService, PlaylistTrackMapper playlistTrackMapper) {
+        this.playlistService = playlistService;
+        this.playlistTrackMapper = playlistTrackMapper;
+    }
+
+    @Transactional
+    public PlaylistTrackResponse addTrack(Long userId, Long playlistId, PlaylistTrackCreateRequest request) {
+        playlistService.validateOwnerForUpdate(userId, playlistId);
+
+        PlaylistTrack playlistTrack = new PlaylistTrack();
+        playlistTrack.setPlaylistId(playlistId);
+        playlistTrack.setSpotifyTrackId(request.spotifyTrackId());
+        playlistTrack.setTitle(request.title());
+        playlistTrack.setArtistName(request.artistName());
+        playlistTrack.setAlbumName(request.albumName());
+        playlistTrack.setAlbumImageUrl(request.albumImageUrl());
+        playlistTrack.setSpotifyUrl(request.spotifyUrl());
+        playlistTrack.setPreviewUrl(request.previewUrl());
+        playlistTrack.setDurationMs(request.durationMs());
+
+        playlistTrackMapper.insert(playlistTrack);
+        return toResponse(getExistingTrack(playlistId, playlistTrack.getPlaylistTrackId()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaylistTrackResponse> getTracks(Long userId, Long playlistId) {
+        playlistService.getPlaylist(userId, playlistId);
+        return getTrackResponses(playlistId);
+    }
+
+    @Transactional
+    public void deleteTrack(Long userId, Long playlistId, Long playlistTrackId) {
+        playlistService.validateOwnerForUpdate(userId, playlistId);
+
+        int deletedCount = playlistTrackMapper.softDelete(playlistId, playlistTrackId);
+        if (deletedCount != 1) {
+            throw new PlaylistTrackNotFoundException();
+        }
+    }
+
+    @Transactional
+    public List<PlaylistTrackResponse> reorderTracks(
+            Long userId,
+            Long playlistId,
+            PlaylistTrackReorderRequest request
+    ) {
+        playlistService.validateOwnerForUpdate(userId, playlistId);
+        validateAllTracksBelongToPlaylist(playlistId, request.playlistTrackIds());
+
+        playlistTrackMapper.moveActiveTracksToTemporaryPositions(playlistId);
+        playlistTrackMapper.updatePositions(playlistId, request.playlistTrackIds());
+
+        return getTrackResponses(playlistId);
+    }
+
+    private PlaylistTrack getExistingTrack(Long playlistId, Long playlistTrackId) {
+        PlaylistTrack playlistTrack = playlistTrackMapper.findById(playlistId, playlistTrackId);
+        if (playlistTrack == null) {
+            throw new PlaylistTrackNotFoundException();
+        }
+        return playlistTrack;
+    }
+
+    private void validateAllTracksBelongToPlaylist(Long playlistId, List<Long> playlistTrackIds) {
+        int totalActiveTrackCount = playlistTrackMapper.countActiveByPlaylistId(playlistId);
+        if (totalActiveTrackCount != playlistTrackIds.size()) {
+            throw new PlaylistTrackNotFoundException();
+        }
+
+        int activeTrackCount = playlistTrackMapper.countActiveByIds(playlistId, playlistTrackIds);
+        if (activeTrackCount != playlistTrackIds.size()) {
+            throw new PlaylistTrackNotFoundException();
+        }
+    }
+
+    private List<PlaylistTrackResponse> getTrackResponses(Long playlistId) {
+        return playlistTrackMapper.findByPlaylistId(playlistId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private PlaylistTrackResponse toResponse(PlaylistTrack playlistTrack) {
+        return new PlaylistTrackResponse(
+                playlistTrack.getPlaylistTrackId(),
+                playlistTrack.getPlaylistId(),
+                playlistTrack.getSpotifyTrackId(),
+                playlistTrack.getTitle(),
+                playlistTrack.getArtistName(),
+                playlistTrack.getAlbumName(),
+                playlistTrack.getAlbumImageUrl(),
+                playlistTrack.getSpotifyUrl(),
+                playlistTrack.getPreviewUrl(),
+                playlistTrack.getDurationMs(),
+                playlistTrack.getPositionNo(),
+                playlistTrack.getCreatedAt()
+        );
+    }
+}

--- a/src/main/resources/mappers/PlaylistMapper.xml
+++ b/src/main/resources/mappers/PlaylistMapper.xml
@@ -48,6 +48,29 @@
           AND U.DELETED_AT IS NULL
     </select>
 
+    <select id="findByIdForUpdate" resultType="com.tunesharehub.entity.Playlist">
+        SELECT
+            P.PLAYLIST_ID,
+            P.USER_ID,
+            U.NICKNAME AS USER_NICKNAME,
+            P.TITLE,
+            P.DESCRIPTION,
+            P.COVER_IMAGE_URL,
+            P.PUBLIC_YN,
+            P.VIEW_COUNT,
+            P.LIKE_COUNT,
+            P.COMMENT_COUNT,
+            P.CREATED_AT,
+            P.UPDATED_AT,
+            P.DELETED_AT
+        FROM PLAYLISTS P
+        JOIN USERS U ON U.USER_ID = P.USER_ID
+        WHERE P.PLAYLIST_ID = #{playlistId}
+          AND P.DELETED_AT IS NULL
+          AND U.DELETED_AT IS NULL
+        FOR UPDATE
+    </select>
+
     <select id="findByUserId" resultType="com.tunesharehub.entity.Playlist">
         SELECT
             P.PLAYLIST_ID,

--- a/src/main/resources/mappers/PlaylistTrackMapper.xml
+++ b/src/main/resources/mappers/PlaylistTrackMapper.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.tunesharehub.mapper.PlaylistTrackMapper">
+
+    <insert id="insert" parameterType="com.tunesharehub.entity.PlaylistTrack">
+        <selectKey keyProperty="playlistTrackId" resultType="long" order="BEFORE">
+            SELECT SEQ_PLAYLIST_TRACKS.NEXTVAL FROM DUAL
+        </selectKey>
+        INSERT INTO PLAYLIST_TRACKS (
+            PLAYLIST_TRACK_ID,
+            PLAYLIST_ID,
+            SPOTIFY_TRACK_ID,
+            TITLE,
+            ARTIST_NAME,
+            ALBUM_NAME,
+            ALBUM_IMAGE_URL,
+            SPOTIFY_URL,
+            PREVIEW_URL,
+            DURATION_MS,
+            POSITION_NO
+        ) VALUES (
+            #{playlistTrackId},
+            #{playlistId},
+            #{spotifyTrackId},
+            #{title},
+            #{artistName},
+            #{albumName, jdbcType=VARCHAR},
+            #{albumImageUrl, jdbcType=VARCHAR},
+            #{spotifyUrl},
+            #{previewUrl, jdbcType=VARCHAR},
+            #{durationMs, jdbcType=NUMERIC},
+            (
+                SELECT NVL(MAX(POSITION_NO), 0) + 1
+                FROM PLAYLIST_TRACKS
+                WHERE PLAYLIST_ID = #{playlistId}
+                  AND DELETED_AT IS NULL
+            )
+        )
+    </insert>
+
+    <select id="findById" resultType="com.tunesharehub.entity.PlaylistTrack">
+        SELECT
+            PLAYLIST_TRACK_ID,
+            PLAYLIST_ID,
+            SPOTIFY_TRACK_ID,
+            TITLE,
+            ARTIST_NAME,
+            ALBUM_NAME,
+            ALBUM_IMAGE_URL,
+            SPOTIFY_URL,
+            PREVIEW_URL,
+            DURATION_MS,
+            POSITION_NO,
+            CREATED_AT,
+            DELETED_AT
+        FROM PLAYLIST_TRACKS
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND PLAYLIST_TRACK_ID = #{playlistTrackId}
+          AND DELETED_AT IS NULL
+    </select>
+
+    <select id="findByPlaylistId" resultType="com.tunesharehub.entity.PlaylistTrack">
+        SELECT
+            PLAYLIST_TRACK_ID,
+            PLAYLIST_ID,
+            SPOTIFY_TRACK_ID,
+            TITLE,
+            ARTIST_NAME,
+            ALBUM_NAME,
+            ALBUM_IMAGE_URL,
+            SPOTIFY_URL,
+            PREVIEW_URL,
+            DURATION_MS,
+            POSITION_NO,
+            CREATED_AT,
+            DELETED_AT
+        FROM PLAYLIST_TRACKS
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+        ORDER BY POSITION_NO ASC, PLAYLIST_TRACK_ID ASC
+    </select>
+
+    <update id="softDelete">
+        UPDATE PLAYLIST_TRACKS
+        SET DELETED_AT = SYSTIMESTAMP
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND PLAYLIST_TRACK_ID = #{playlistTrackId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <select id="countActiveByIds" resultType="int">
+        SELECT COUNT(*)
+        FROM PLAYLIST_TRACKS
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+          AND PLAYLIST_TRACK_ID IN
+          <foreach collection="playlistTrackIds" item="playlistTrackId" open="(" separator="," close=")">
+              #{playlistTrackId}
+          </foreach>
+    </select>
+
+    <select id="countActiveByPlaylistId" resultType="int">
+        SELECT COUNT(*)
+        FROM PLAYLIST_TRACKS
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+    </select>
+
+    <update id="moveActiveTracksToTemporaryPositions">
+        UPDATE PLAYLIST_TRACKS
+        SET POSITION_NO = -PLAYLIST_TRACK_ID
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+    </update>
+
+    <update id="updatePositions">
+        UPDATE PLAYLIST_TRACKS
+        SET POSITION_NO = CASE PLAYLIST_TRACK_ID
+            <foreach collection="playlistTrackIds" item="playlistTrackId" index="positionIndex">
+                WHEN #{playlistTrackId} THEN #{positionIndex} + 1
+            </foreach>
+        END
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND DELETED_AT IS NULL
+          AND PLAYLIST_TRACK_ID IN
+          <foreach collection="playlistTrackIds" item="playlistTrackId" open="(" separator="," close=")">
+              #{playlistTrackId}
+          </foreach>
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 작업 내용

- 플레이리스트에 Spotify 트랙 추가 API 추가
- 플레이리스트 트랙 목록 조회 API 추가
- 플레이리스트 트랙 soft delete API 추가
- 플레이리스트 트랙 순서 변경 API 추가
- PlaylistTrack DTO, Entity, Service, Mapper/XML 추가
- 플레이리스트 작성자 권한 검사 연동
- 순서 변경 시 active 트랙 전체 집합 검증 및 unique index 충돌 회피 처리

## API

- POST /api/playlists/{playlistId}/tracks
- GET /api/playlists/{playlistId}/tracks
- DELETE /api/playlists/{playlistId}/tracks/{playlistTrackId}
- PUT /api/playlists/{playlistId}/tracks/positions

## 검증

- ./gradlew test
- git diff --check

Closes #8