### PR TITLE
[Spotify][Backend] Spotify 트랙 검색 API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/config/WebConfig.java
+++ b/src/main/java/com/tunesharehub/config/WebConfig.java
@@ -23,7 +23,12 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/auth/login", "/api/auth/refresh", "/api/auth/logout");
+                .excludePathPatterns(
+                        "/api/auth/login",
+                        "/api/auth/refresh",
+                        "/api/auth/logout",
+                        "/api/spotify/search/**"
+                );
     }
 
     @Override

--- a/src/main/java/com/tunesharehub/controller/SpotifyController.java
+++ b/src/main/java/com/tunesharehub/controller/SpotifyController.java
@@ -1,0 +1,36 @@
+package com.tunesharehub.controller;
+
+import com.tunesharehub.dto.TrackSearchResponse;
+import com.tunesharehub.service.SpotifyService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/spotify")
+public class SpotifyController {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+
+    private final SpotifyService spotifyService;
+
+    public SpotifyController(SpotifyService spotifyService) {
+        this.spotifyService = spotifyService;
+    }
+
+    @GetMapping("/search/tracks")
+    public TrackSearchResponse searchTracks(
+            @RequestParam @NotBlank String q,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(10) int size
+    ) {
+        return spotifyService.searchTracks(q, page, size);
+    }
+}

--- a/src/main/java/com/tunesharehub/dto/TrackSearchItemResponse.java
+++ b/src/main/java/com/tunesharehub/dto/TrackSearchItemResponse.java
@@ -1,0 +1,13 @@
+package com.tunesharehub.dto;
+
+public record TrackSearchItemResponse(
+        String spotifyTrackId,
+        String title,
+        String artistName,
+        String albumName,
+        String albumImageUrl,
+        String spotifyUrl,
+        String previewUrl,
+        Long durationMs
+) {
+}

--- a/src/main/java/com/tunesharehub/dto/TrackSearchResponse.java
+++ b/src/main/java/com/tunesharehub/dto/TrackSearchResponse.java
@@ -1,0 +1,13 @@
+package com.tunesharehub.dto;
+
+import java.util.List;
+
+public record TrackSearchResponse(
+        String query,
+        int page,
+        int size,
+        int total,
+        boolean hasNext,
+        List<TrackSearchItemResponse> tracks
+) {
+}

--- a/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tunesharehub/exception/GlobalExceptionHandler.java
@@ -49,6 +49,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
     }
 
+    @ExceptionHandler(SpotifyApiException.class)
+    public ResponseEntity<ErrorResponse> handleSpotifyApiException(SpotifyApiException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(new ErrorResponse(exception.getCode(), exception.getMessage()));
+    }
+
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException exception) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/tunesharehub/exception/SpotifyApiException.java
+++ b/src/main/java/com/tunesharehub/exception/SpotifyApiException.java
@@ -1,0 +1,8 @@
+package com.tunesharehub.exception;
+
+public class SpotifyApiException extends BusinessException {
+
+    public SpotifyApiException(String message) {
+        super("SPOTIFY_API_ERROR", message);
+    }
+}

--- a/src/main/java/com/tunesharehub/service/SpotifyService.java
+++ b/src/main/java/com/tunesharehub/service/SpotifyService.java
@@ -1,0 +1,64 @@
+package com.tunesharehub.service;
+
+import com.tunesharehub.dto.TrackSearchItemResponse;
+import com.tunesharehub.dto.TrackSearchResponse;
+import com.tunesharehub.exception.SpotifyApiException;
+import com.tunesharehub.spotify.SpotifyClient;
+import com.tunesharehub.spotify.SpotifySearchResponse;
+import com.tunesharehub.spotify.SpotifyTrack;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SpotifyService {
+
+    private final SpotifyClient spotifyClient;
+
+    public SpotifyService(SpotifyClient spotifyClient) {
+        this.spotifyClient = spotifyClient;
+    }
+
+    public TrackSearchResponse searchTracks(String query, int page, int size) {
+        int offset = page * size;
+        if (offset > 1000) {
+            throw new SpotifyApiException("Spotify 검색 offset은 1000을 초과할 수 없습니다.");
+        }
+
+        SpotifySearchResponse response = spotifyClient.searchTracks(query, size, offset);
+        if (response == null) {
+            throw new SpotifyApiException("Spotify 트랙 검색 응답이 올바르지 않습니다.");
+        }
+
+        SpotifySearchResponse.TrackPage tracks = response.tracks();
+        if (tracks == null || tracks.items() == null) {
+            throw new SpotifyApiException("Spotify 트랙 검색 응답이 올바르지 않습니다.");
+        }
+
+        List<TrackSearchItemResponse> items = tracks.items()
+                .stream()
+                .map(this::toTrackSearchItemResponse)
+                .toList();
+
+        return new TrackSearchResponse(
+                query,
+                page,
+                size,
+                tracks.total(),
+                tracks.next() != null,
+                items
+        );
+    }
+
+    private TrackSearchItemResponse toTrackSearchItemResponse(SpotifyTrack track) {
+        return new TrackSearchItemResponse(
+                track.id(),
+                track.name(),
+                track.artistName(),
+                track.albumName(),
+                track.albumImageUrl(),
+                track.spotifyUrl(),
+                track.previewUrl(),
+                track.durationMs()
+        );
+    }
+}

--- a/src/main/java/com/tunesharehub/spotify/SpotifyClient.java
+++ b/src/main/java/com/tunesharehub/spotify/SpotifyClient.java
@@ -1,0 +1,119 @@
+package com.tunesharehub.spotify;
+
+import com.tunesharehub.exception.SpotifyApiException;
+import java.net.URI;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class SpotifyClient {
+
+    private static final Logger log = LoggerFactory.getLogger(SpotifyClient.class);
+
+    private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+    private static final String TRACK_SEARCH_TYPE = "track";
+    private static final String DEFAULT_MARKET = "KR";
+    private static final long TOKEN_EXPIRATION_BUFFER_SECONDS = 60;
+
+    private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String tokenUrl;
+    private final String apiBaseUrl;
+
+    private volatile String cachedAccessToken;
+    private volatile Instant tokenExpiresAt = Instant.EPOCH;
+
+    public SpotifyClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${spotify.client-id}") String clientId,
+            @Value("${spotify.client-secret}") String clientSecret,
+            @Value("${spotify.token-url}") String tokenUrl,
+            @Value("${spotify.api-base-url}") String apiBaseUrl
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.tokenUrl = tokenUrl;
+        this.apiBaseUrl = apiBaseUrl;
+    }
+
+    public SpotifySearchResponse searchTracks(String query, int limit, int offset) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(apiBaseUrl)
+                .path("/search")
+                .queryParam("q", query)
+                .queryParam("type", TRACK_SEARCH_TYPE)
+                .queryParam("market", DEFAULT_MARKET)
+                .queryParam("limit", limit)
+                .queryParam("offset", offset)
+                .build()
+                .toUri();
+
+        try {
+            return restClient.get()
+                    .uri(uri)
+                    .headers(headers -> headers.setBearerAuth(getAccessToken()))
+                    .retrieve()
+                    .body(SpotifySearchResponse.class);
+        } catch (RestClientResponseException | ResourceAccessException exception) {
+            log.warn("Spotify track search request failed: {}", exception.getMessage());
+            throw new SpotifyApiException("Spotify 트랙 검색에 실패했습니다.");
+        }
+    }
+
+    private String getAccessToken() {
+        if (cachedAccessToken != null && Instant.now().isBefore(tokenExpiresAt)) {
+            return cachedAccessToken;
+        }
+
+        synchronized (this) {
+            if (cachedAccessToken != null && Instant.now().isBefore(tokenExpiresAt)) {
+                return cachedAccessToken;
+            }
+
+            validateCredentials();
+            MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+            body.add("grant_type", CLIENT_CREDENTIALS_GRANT_TYPE);
+
+            SpotifyTokenResponse response;
+            try {
+                response = restClient.post()
+                        .uri(tokenUrl)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .headers(headers -> headers.setBasicAuth(clientId, clientSecret))
+                        .body(body)
+                        .retrieve()
+                        .body(SpotifyTokenResponse.class);
+            } catch (RestClientResponseException | ResourceAccessException exception) {
+                log.warn("Spotify access token request failed: {}", exception.getMessage());
+                throw new SpotifyApiException("Spotify access token 발급에 실패했습니다.");
+            }
+
+            if (response == null || response.accessToken() == null || response.expiresIn() == null) {
+                throw new SpotifyApiException("Spotify access token 응답이 올바르지 않습니다.");
+            }
+
+            cachedAccessToken = response.accessToken();
+            long cacheSeconds = Math.max(1L, response.expiresIn() - TOKEN_EXPIRATION_BUFFER_SECONDS);
+            tokenExpiresAt = Instant.now().plusSeconds(cacheSeconds);
+            return cachedAccessToken;
+        }
+    }
+
+    private void validateCredentials() {
+        if (clientId == null || clientId.isBlank() || clientSecret == null || clientSecret.isBlank()) {
+            throw new SpotifyApiException("Spotify client 설정이 필요합니다.");
+        }
+    }
+}

--- a/src/main/java/com/tunesharehub/spotify/SpotifySearchResponse.java
+++ b/src/main/java/com/tunesharehub/spotify/SpotifySearchResponse.java
@@ -1,0 +1,18 @@
+package com.tunesharehub.spotify;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SpotifySearchResponse(
+        TrackPage tracks
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record TrackPage(
+            String next,
+            int total,
+            List<SpotifyTrack> items
+    ) {
+    }
+}

--- a/src/main/java/com/tunesharehub/spotify/SpotifyTokenResponse.java
+++ b/src/main/java/com/tunesharehub/spotify/SpotifyTokenResponse.java
@@ -1,0 +1,14 @@
+package com.tunesharehub.spotify;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SpotifyTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("expires_in")
+        Long expiresIn
+) {
+}

--- a/src/main/java/com/tunesharehub/spotify/SpotifyTrack.java
+++ b/src/main/java/com/tunesharehub/spotify/SpotifyTrack.java
@@ -1,0 +1,68 @@
+package com.tunesharehub.spotify;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SpotifyTrack(
+        String id,
+        String name,
+        List<SpotifyArtist> artists,
+        SpotifyAlbum album,
+        @JsonProperty("external_urls")
+        Map<String, String> externalUrls,
+        @JsonProperty("preview_url")
+        String previewUrl,
+        @JsonProperty("duration_ms")
+        Long durationMs
+) {
+
+    public String artistName() {
+        if (artists == null || artists.isEmpty()) {
+            return "";
+        }
+        return String.join(", ", artists.stream().map(SpotifyArtist::name).toList());
+    }
+
+    public String albumName() {
+        if (album == null) {
+            return null;
+        }
+        return album.name();
+    }
+
+    public String albumImageUrl() {
+        if (album == null || album.images() == null || album.images().isEmpty()) {
+            return null;
+        }
+        return album.images().get(0).url();
+    }
+
+    public String spotifyUrl() {
+        if (externalUrls == null) {
+            return null;
+        }
+        return externalUrls.get("spotify");
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SpotifyArtist(
+            String name
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SpotifyAlbum(
+            String name,
+            List<SpotifyImage> images
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record SpotifyImage(
+            String url
+    ) {
+    }
+}


### PR DESCRIPTION
## 작업 내용

- Spotify Client Credentials access token 요청 구현
- Spotify access token 캐싱 구현
- Spotify track search API 연동
- Spotify 검색 응답을 프론트/트랙 추가용 DTO로 변환
- Spotify API 실패 시 502 공통 예외 응답 추가

## API

- GET /api/spotify/search/tracks?q=&page=&size=

## 참고

- Client Credentials Flow: https://developer.spotify.com/documentation/web-api/tutorials/client-credentials-flow
- Search for Item: https://developer.spotify.com/documentation/web-api/reference/search

## 검증

- ./gradlew test
- git diff --check

Closes #10