### PR TITLE
[Playlist][Backend] 공개 플레이리스트 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
+++ b/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
@@ -2,6 +2,7 @@ package com.tunesharehub.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -13,6 +14,7 @@ public class JwtInterceptor implements HandlerInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String PUBLIC_PLAYLISTS_PATH = "/api/playlists";
 
     private final JwtProvider jwtProvider;
 
@@ -25,6 +27,9 @@ public class JwtInterceptor implements HandlerInterceptor {
         if (!(handler instanceof HandlerMethod)) {
             return true;
         }
+        if (isPublicEndpoint(request)) {
+            return true;
+        }
 
         String authorization = request.getHeader(AUTHORIZATION_HEADER);
         if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
@@ -34,5 +39,19 @@ public class JwtInterceptor implements HandlerInterceptor {
         String accessToken = authorization.substring(BEARER_PREFIX.length());
         request.setAttribute(AUTH_USER_ATTRIBUTE, jwtProvider.parseAccessToken(accessToken));
         return true;
+    }
+
+    private boolean isPublicEndpoint(HttpServletRequest request) {
+        return HttpMethod.GET.matches(request.getMethod())
+                && PUBLIC_PLAYLISTS_PATH.equals(getRequestPath(request));
+    }
+
+    private String getRequestPath(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath == null || contextPath.isBlank()) {
+            return requestUri;
+        }
+        return requestUri.substring(contextPath.length());
     }
 }

--- a/src/main/java/com/tunesharehub/controller/PlaylistController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistController.java
@@ -59,7 +59,7 @@ public class PlaylistController {
             @RequestParam(defaultValue = "") String keyword,
             @RequestParam(defaultValue = "title") String searchType,
             @RequestParam(defaultValue = "latest") String sort,
-            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) @Max(10000) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
     ) {
         return playlistService.getPublicPlaylists(keyword, searchType, sort, page, size);

--- a/src/main/java/com/tunesharehub/controller/PlaylistController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistController.java
@@ -54,6 +54,17 @@ public class PlaylistController {
         return playlistService.getPlaylist(authUser.userId(), playlistId);
     }
 
+    @GetMapping("/playlists")
+    public List<PlaylistResponse> getPublicPlaylists(
+            @RequestParam(defaultValue = "") String keyword,
+            @RequestParam(defaultValue = "title") String searchType,
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
+    ) {
+        return playlistService.getPublicPlaylists(keyword, searchType, sort, page, size);
+    }
+
     @GetMapping("/me/playlists")
     public List<PlaylistResponse> getMyPlaylists(
             @CurrentUser AuthUser authUser,

--- a/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
@@ -22,6 +22,14 @@ public interface PlaylistMapper {
             @Param("size") int size
     );
 
+    List<Playlist> findPublicPlaylists(
+            @Param("keyword") String keyword,
+            @Param("searchType") String searchType,
+            @Param("sort") String sort,
+            @Param("offset") int offset,
+            @Param("size") int size
+    );
+
     int updateOwned(Playlist playlist);
 
     int softDeleteOwned(

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -4,6 +4,7 @@ import com.tunesharehub.dto.PlaylistCreateRequest;
 import com.tunesharehub.dto.PlaylistResponse;
 import com.tunesharehub.dto.PlaylistUpdateRequest;
 import com.tunesharehub.entity.Playlist;
+import com.tunesharehub.exception.BusinessException;
 import com.tunesharehub.exception.ForbiddenException;
 import com.tunesharehub.exception.PlaylistNotFoundException;
 import com.tunesharehub.mapper.PlaylistMapper;
@@ -16,6 +17,12 @@ public class PlaylistService {
 
     private static final String PUBLIC_YN_TRUE = "Y";
     private static final String PUBLIC_YN_FALSE = "N";
+    private static final String SEARCH_TYPE_TITLE = "title";
+    private static final String SEARCH_TYPE_AUTHOR = "author";
+    private static final String SORT_LATEST = "latest";
+    private static final String SORT_VIEW = "view";
+    private static final String SORT_LIKE = "like";
+    private static final String SORT_COMMENT = "comment";
 
     private final PlaylistMapper playlistMapper;
 
@@ -47,6 +54,31 @@ public class PlaylistService {
     public List<PlaylistResponse> getMyPlaylists(Long userId, int page, int size) {
         int offset = page * size;
         return playlistMapper.findByUserId(userId, offset, size)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaylistResponse> getPublicPlaylists(
+            String keyword,
+            String searchType,
+            String sort,
+            int page,
+            int size
+    ) {
+        String normalizedKeyword = normalizeKeyword(keyword);
+        String normalizedSearchType = normalizeSearchType(searchType);
+        String normalizedSort = normalizeSort(sort);
+        int offset = page * size;
+
+        return playlistMapper.findPublicPlaylists(
+                        normalizedKeyword,
+                        normalizedSearchType,
+                        normalizedSort,
+                        offset,
+                        size
+                )
                 .stream()
                 .map(this::toResponse)
                 .toList();
@@ -163,5 +195,32 @@ public class PlaylistService {
             return PUBLIC_YN_TRUE;
         }
         return PUBLIC_YN_FALSE;
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null) {
+            return "";
+        }
+        return keyword.trim();
+    }
+
+    private String normalizeSearchType(String searchType) {
+        if (SEARCH_TYPE_AUTHOR.equals(searchType)) {
+            return SEARCH_TYPE_AUTHOR;
+        }
+        if (searchType == null || searchType.isBlank() || SEARCH_TYPE_TITLE.equals(searchType)) {
+            return SEARCH_TYPE_TITLE;
+        }
+        throw new BusinessException("INVALID_SEARCH_TYPE", "검색 타입이 올바르지 않습니다.");
+    }
+
+    private String normalizeSort(String sort) {
+        if (sort == null || sort.isBlank() || SORT_LATEST.equals(sort)) {
+            return SORT_LATEST;
+        }
+        if (SORT_VIEW.equals(sort) || SORT_LIKE.equals(sort) || SORT_COMMENT.equals(sort)) {
+            return sort;
+        }
+        throw new BusinessException("INVALID_SORT", "정렬 값이 올바르지 않습니다.");
     }
 }

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -9,6 +9,7 @@ import com.tunesharehub.exception.ForbiddenException;
 import com.tunesharehub.exception.PlaylistNotFoundException;
 import com.tunesharehub.mapper.PlaylistMapper;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -205,21 +206,32 @@ public class PlaylistService {
     }
 
     private String normalizeSearchType(String searchType) {
-        if (SEARCH_TYPE_AUTHOR.equals(searchType)) {
+        if (searchType == null || searchType.isBlank()) {
+            return SEARCH_TYPE_TITLE;
+        }
+
+        String normalizedSearchType = searchType.trim().toLowerCase(Locale.ROOT);
+        if (SEARCH_TYPE_AUTHOR.equals(normalizedSearchType)) {
             return SEARCH_TYPE_AUTHOR;
         }
-        if (searchType == null || searchType.isBlank() || SEARCH_TYPE_TITLE.equals(searchType)) {
+        if (SEARCH_TYPE_TITLE.equals(normalizedSearchType)) {
             return SEARCH_TYPE_TITLE;
         }
         throw new BusinessException("INVALID_SEARCH_TYPE", "검색 타입이 올바르지 않습니다.");
     }
 
     private String normalizeSort(String sort) {
-        if (sort == null || sort.isBlank() || SORT_LATEST.equals(sort)) {
+        if (sort == null || sort.isBlank()) {
             return SORT_LATEST;
         }
-        if (SORT_VIEW.equals(sort) || SORT_LIKE.equals(sort) || SORT_COMMENT.equals(sort)) {
-            return sort;
+
+        String normalizedSort = sort.trim().toLowerCase(Locale.ROOT);
+        if (SORT_LATEST.equals(normalizedSort)) {
+            return SORT_LATEST;
+        }
+        if (SORT_VIEW.equals(normalizedSort) || SORT_LIKE.equals(normalizedSort)
+                || SORT_COMMENT.equals(normalizedSort)) {
+            return normalizedSort;
         }
         throw new BusinessException("INVALID_SORT", "정렬 값이 올바르지 않습니다.");
     }

--- a/src/main/resources/mappers/PlaylistMapper.xml
+++ b/src/main/resources/mappers/PlaylistMapper.xml
@@ -107,6 +107,53 @@
         OFFSET #{offset} ROWS FETCH NEXT #{size} ROWS ONLY
     </select>
 
+    <select id="findPublicPlaylists" resultType="com.tunesharehub.entity.Playlist">
+        SELECT
+            P.PLAYLIST_ID,
+            P.USER_ID,
+            U.NICKNAME AS USER_NICKNAME,
+            P.TITLE,
+            P.DESCRIPTION,
+            P.COVER_IMAGE_URL,
+            P.PUBLIC_YN,
+            P.VIEW_COUNT,
+            P.LIKE_COUNT,
+            P.COMMENT_COUNT,
+            P.CREATED_AT,
+            P.UPDATED_AT,
+            P.DELETED_AT
+        FROM PLAYLISTS P
+        JOIN USERS U ON U.USER_ID = P.USER_ID
+        WHERE P.PUBLIC_YN = 'Y'
+          AND P.DELETED_AT IS NULL
+          AND U.DELETED_AT IS NULL
+        <if test="keyword != null and keyword != ''">
+            <choose>
+                <when test="searchType == 'author'">
+                    AND U.NICKNAME LIKE '%' || #{keyword} || '%'
+                </when>
+                <otherwise>
+                    AND P.TITLE LIKE '%' || #{keyword} || '%'
+                </otherwise>
+            </choose>
+        </if>
+        <choose>
+            <when test="sort == 'view'">
+                ORDER BY P.VIEW_COUNT DESC, P.CREATED_AT DESC, P.PLAYLIST_ID DESC
+            </when>
+            <when test="sort == 'like'">
+                ORDER BY P.LIKE_COUNT DESC, P.CREATED_AT DESC, P.PLAYLIST_ID DESC
+            </when>
+            <when test="sort == 'comment'">
+                ORDER BY P.COMMENT_COUNT DESC, P.CREATED_AT DESC, P.PLAYLIST_ID DESC
+            </when>
+            <otherwise>
+                ORDER BY P.CREATED_AT DESC, P.PLAYLIST_ID DESC
+            </otherwise>
+        </choose>
+        OFFSET #{offset} ROWS FETCH NEXT #{size} ROWS ONLY
+    </select>
+
     <update id="updateOwned" parameterType="com.tunesharehub.entity.Playlist">
         UPDATE PLAYLISTS
         SET

--- a/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
+++ b/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
@@ -1,0 +1,39 @@
+package com.tunesharehub.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+
+class JwtInterceptorTest {
+
+    private final JwtProvider jwtProvider = mock(JwtProvider.class);
+    private final JwtInterceptor jwtInterceptor = new JwtInterceptor(jwtProvider);
+    private final MockHttpServletResponse response = new MockHttpServletResponse();
+    private final HandlerMethod handler = mock(HandlerMethod.class);
+
+    @Test
+    void publicPlaylistListDoesNotRequireToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists");
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        verify(jwtProvider, never()).parseAccessToken(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void playlistCreateStillRequiresToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/playlists");
+
+        assertThatThrownBy(() -> jwtInterceptor.preHandle(request, response, handler))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("인증 토큰이 필요합니다.");
+    }
+}

--- a/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
@@ -43,7 +43,7 @@ class PlaylistServiceTest {
         when(playlistMapper.findPublicPlaylists("alice", "author", "like", 40, 20))
                 .thenReturn(List.of());
 
-        playlistService.getPublicPlaylists(" alice ", "author", "like", 2, 20);
+        playlistService.getPublicPlaylists(" alice ", " Author ", " LIKE ", 2, 20);
 
         verify(playlistMapper).findPublicPlaylists("alice", "author", "like", 40, 20);
     }

--- a/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
@@ -1,0 +1,77 @@
+package com.tunesharehub.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tunesharehub.dto.PlaylistResponse;
+import com.tunesharehub.entity.Playlist;
+import com.tunesharehub.exception.BusinessException;
+import com.tunesharehub.mapper.PlaylistMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistServiceTest {
+
+    @Mock
+    private PlaylistMapper playlistMapper;
+
+    @InjectMocks
+    private PlaylistService playlistService;
+
+    @Test
+    void getPublicPlaylistsNormalizesBlankParameters() {
+        Playlist playlist = publicPlaylist();
+        when(playlistMapper.findPublicPlaylists("", "title", "latest", 0, 20))
+                .thenReturn(List.of(playlist));
+
+        List<PlaylistResponse> responses = playlistService.getPublicPlaylists("  ", "", "", 0, 20);
+
+        verify(playlistMapper).findPublicPlaylists("", "title", "latest", 0, 20);
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).playlistId()).isEqualTo(10L);
+    }
+
+    @Test
+    void getPublicPlaylistsAcceptsAuthorSearchAndLikeSort() {
+        when(playlistMapper.findPublicPlaylists("alice", "author", "like", 40, 20))
+                .thenReturn(List.of());
+
+        playlistService.getPublicPlaylists(" alice ", "author", "like", 2, 20);
+
+        verify(playlistMapper).findPublicPlaylists("alice", "author", "like", 40, 20);
+    }
+
+    @Test
+    void getPublicPlaylistsRejectsInvalidSearchType() {
+        assertThatThrownBy(() -> playlistService.getPublicPlaylists("", "description", "latest", 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("검색 타입이 올바르지 않습니다.");
+    }
+
+    @Test
+    void getPublicPlaylistsRejectsInvalidSort() {
+        assertThatThrownBy(() -> playlistService.getPublicPlaylists("", "title", "popular", 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("정렬 값이 올바르지 않습니다.");
+    }
+
+    private Playlist publicPlaylist() {
+        Playlist playlist = new Playlist();
+        playlist.setPlaylistId(10L);
+        playlist.setUserId(1L);
+        playlist.setUserNickname("alice");
+        playlist.setTitle("morning mix");
+        playlist.setPublicYn("Y");
+        playlist.setViewCount(0L);
+        playlist.setLikeCount(0L);
+        playlist.setCommentCount(0L);
+        return playlist;
+    }
+}


### PR DESCRIPTION
## Summary
- 공개 플레이리스트 목록 조회 API 추가
- keyword/searchType 기반 제목/작성자 검색 지원
- latest/view/like/comment 정렬 whitelist 적용
- 공개 목록 조회 파라미터 정규화 및 검증 단위 테스트 추가

## API
- GET /api/playlists?keyword=&searchType=&sort=&page=&size=

## Test
- ./gradlew test
- git diff --check