### PR TITLE
[Playlist][Backend] 공개 플레이리스트 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/auth/AuthUser.java
+++ b/src/main/java/com/tunesharehub/auth/AuthUser.java
@@ -6,4 +6,11 @@ public record AuthUser(
         String nickname,
         String role
 ) {
+
+    public static Long userIdOrNull(AuthUser authUser) {
+        if (authUser == null) {
+            return null;
+        }
+        return authUser.userId();
+    }
 }

--- a/src/main/java/com/tunesharehub/auth/AuthUserArgumentResolver.java
+++ b/src/main/java/com/tunesharehub/auth/AuthUserArgumentResolver.java
@@ -28,6 +28,10 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
                 NativeWebRequest.SCOPE_REQUEST
         );
         if (!(authUser instanceof AuthUser)) {
+            CurrentUser currentUser = parameter.getParameterAnnotation(CurrentUser.class);
+            if (currentUser != null && !currentUser.required()) {
+                return null;
+            }
             throw new UnauthorizedException("인증 사용자 정보가 필요합니다.");
         }
         return authUser;

--- a/src/main/java/com/tunesharehub/auth/CurrentUser.java
+++ b/src/main/java/com/tunesharehub/auth/CurrentUser.java
@@ -8,4 +8,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CurrentUser {
+
+    boolean required() default true;
 }

--- a/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
+++ b/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
@@ -15,6 +15,8 @@ public class JwtInterceptor implements HandlerInterceptor {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String PUBLIC_PLAYLISTS_PATH = "/api/playlists";
+    private static final int PLAYLIST_ID_SEGMENT_COUNT = 4;
+    private static final int PLAYLIST_CHILD_SEGMENT_COUNT = 5;
 
     private final JwtProvider jwtProvider;
 
@@ -27,11 +29,11 @@ public class JwtInterceptor implements HandlerInterceptor {
         if (!(handler instanceof HandlerMethod)) {
             return true;
         }
-        if (isPublicEndpoint(request)) {
-            return true;
-        }
 
         String authorization = request.getHeader(AUTHORIZATION_HEADER);
+        if (authorization == null && isPublicEndpoint(request)) {
+            return true;
+        }
         if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
             throw new UnauthorizedException("인증 토큰이 필요합니다.");
         }
@@ -42,8 +44,25 @@ public class JwtInterceptor implements HandlerInterceptor {
     }
 
     private boolean isPublicEndpoint(HttpServletRequest request) {
-        return HttpMethod.GET.matches(request.getMethod())
-                && PUBLIC_PLAYLISTS_PATH.equals(getRequestPath(request));
+        if (!HttpMethod.GET.matches(request.getMethod())) {
+            return false;
+        }
+
+        String requestPath = getRequestPath(request);
+        if (PUBLIC_PLAYLISTS_PATH.equals(requestPath)) {
+            return true;
+        }
+        if (!requestPath.startsWith(PUBLIC_PLAYLISTS_PATH + "/")) {
+            return false;
+        }
+
+        String[] segments = requestPath.split("/");
+        if (segments.length == PLAYLIST_ID_SEGMENT_COUNT) {
+            return isPositiveLong(segments[3]);
+        }
+        return segments.length == PLAYLIST_CHILD_SEGMENT_COUNT
+                && isPositiveLong(segments[3])
+                && ("tracks".equals(segments[4]) || "comments".equals(segments[4]));
     }
 
     private String getRequestPath(HttpServletRequest request) {
@@ -53,5 +72,13 @@ public class JwtInterceptor implements HandlerInterceptor {
             return requestUri;
         }
         return requestUri.substring(contextPath.length());
+    }
+
+    private boolean isPositiveLong(String value) {
+        try {
+            return Long.parseLong(value) > 0;
+        } catch (NumberFormatException exception) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
+++ b/src/main/java/com/tunesharehub/auth/JwtInterceptor.java
@@ -2,6 +2,7 @@ package com.tunesharehub.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.regex.Pattern;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
@@ -14,9 +15,10 @@ public class JwtInterceptor implements HandlerInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final String PUBLIC_PLAYLISTS_PATH = "/api/playlists";
-    private static final int PLAYLIST_ID_SEGMENT_COUNT = 4;
-    private static final int PLAYLIST_CHILD_SEGMENT_COUNT = 5;
+    private static final Pattern PUBLIC_PLAYLIST_LIST_PATTERN = Pattern.compile("^/api/playlists/?$");
+    private static final Pattern PUBLIC_PLAYLIST_DETAIL_PATTERN = Pattern.compile("^/api/playlists/[1-9]\\d*/?$");
+    private static final Pattern PUBLIC_PLAYLIST_CHILD_PATTERN =
+            Pattern.compile("^/api/playlists/[1-9]\\d*/(tracks|comments)/?$");
 
     private final JwtProvider jwtProvider;
 
@@ -49,20 +51,9 @@ public class JwtInterceptor implements HandlerInterceptor {
         }
 
         String requestPath = getRequestPath(request);
-        if (PUBLIC_PLAYLISTS_PATH.equals(requestPath)) {
-            return true;
-        }
-        if (!requestPath.startsWith(PUBLIC_PLAYLISTS_PATH + "/")) {
-            return false;
-        }
-
-        String[] segments = requestPath.split("/");
-        if (segments.length == PLAYLIST_ID_SEGMENT_COUNT) {
-            return isPositiveLong(segments[3]);
-        }
-        return segments.length == PLAYLIST_CHILD_SEGMENT_COUNT
-                && isPositiveLong(segments[3])
-                && ("tracks".equals(segments[4]) || "comments".equals(segments[4]));
+        return PUBLIC_PLAYLIST_LIST_PATTERN.matcher(requestPath).matches()
+                || PUBLIC_PLAYLIST_DETAIL_PATTERN.matcher(requestPath).matches()
+                || PUBLIC_PLAYLIST_CHILD_PATTERN.matcher(requestPath).matches();
     }
 
     private String getRequestPath(HttpServletRequest request) {
@@ -74,11 +65,4 @@ public class JwtInterceptor implements HandlerInterceptor {
         return requestUri.substring(contextPath.length());
     }
 
-    private boolean isPositiveLong(String value) {
-        try {
-            return Long.parseLong(value) > 0;
-        } catch (NumberFormatException exception) {
-            return false;
-        }
-    }
 }

--- a/src/main/java/com/tunesharehub/controller/CommentController.java
+++ b/src/main/java/com/tunesharehub/controller/CommentController.java
@@ -51,7 +51,7 @@ public class CommentController {
     public List<CommentResponse> getComments(
             @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId,
-            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) @Max(10000) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
     ) {
         return commentService.getComments(getUserId(authUser), playlistId, page, size);

--- a/src/main/java/com/tunesharehub/controller/CommentController.java
+++ b/src/main/java/com/tunesharehub/controller/CommentController.java
@@ -54,7 +54,7 @@ public class CommentController {
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) @Max(10000) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
     ) {
-        return commentService.getComments(getUserId(authUser), playlistId, page, size);
+        return commentService.getComments(AuthUser.userIdOrNull(authUser), playlistId, page, size);
     }
 
     @PutMapping("/comments/{commentId}")
@@ -73,12 +73,5 @@ public class CommentController {
             @PathVariable Long commentId
     ) {
         commentService.deleteComment(authUser.userId(), commentId);
-    }
-
-    private Long getUserId(AuthUser authUser) {
-        if (authUser == null) {
-            return null;
-        }
-        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/controller/CommentController.java
+++ b/src/main/java/com/tunesharehub/controller/CommentController.java
@@ -49,12 +49,12 @@ public class CommentController {
 
     @GetMapping("/playlists/{playlistId}/comments")
     public List<CommentResponse> getComments(
-            @CurrentUser AuthUser authUser,
+            @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId,
             @RequestParam(defaultValue = "" + DEFAULT_PAGE) @Min(0) int page,
             @RequestParam(defaultValue = "" + DEFAULT_SIZE) @Min(1) @Max(100) int size
     ) {
-        return commentService.getComments(authUser.userId(), playlistId, page, size);
+        return commentService.getComments(getUserId(authUser), playlistId, page, size);
     }
 
     @PutMapping("/comments/{commentId}")
@@ -73,5 +73,12 @@ public class CommentController {
             @PathVariable Long commentId
     ) {
         commentService.deleteComment(authUser.userId(), commentId);
+    }
+
+    private Long getUserId(AuthUser authUser) {
+        if (authUser == null) {
+            return null;
+        }
+        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/controller/PlaylistController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistController.java
@@ -51,7 +51,7 @@ public class PlaylistController {
             @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId
     ) {
-        return playlistService.getPlaylistDetail(getUserId(authUser), playlistId);
+        return playlistService.getPlaylistDetail(AuthUser.userIdOrNull(authUser), playlistId);
     }
 
     @GetMapping("/playlists")
@@ -90,12 +90,5 @@ public class PlaylistController {
             @PathVariable Long playlistId
     ) {
         playlistService.deletePlaylist(authUser.userId(), playlistId);
-    }
-
-    private Long getUserId(AuthUser authUser) {
-        if (authUser == null) {
-            return null;
-        }
-        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/controller/PlaylistController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistController.java
@@ -48,10 +48,10 @@ public class PlaylistController {
 
     @GetMapping("/playlists/{playlistId}")
     public PlaylistResponse getPlaylist(
-            @CurrentUser AuthUser authUser,
+            @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId
     ) {
-        return playlistService.getPlaylist(authUser.userId(), playlistId);
+        return playlistService.getPlaylistDetail(getUserId(authUser), playlistId);
     }
 
     @GetMapping("/playlists")
@@ -90,5 +90,12 @@ public class PlaylistController {
             @PathVariable Long playlistId
     ) {
         playlistService.deletePlaylist(authUser.userId(), playlistId);
+    }
+
+    private Long getUserId(AuthUser authUser) {
+        if (authUser == null) {
+            return null;
+        }
+        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
@@ -41,10 +41,10 @@ public class PlaylistTrackController {
 
     @GetMapping
     public List<PlaylistTrackResponse> getTracks(
-            @CurrentUser AuthUser authUser,
+            @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId
     ) {
-        return playlistTrackService.getTracks(authUser.userId(), playlistId);
+        return playlistTrackService.getTracks(getUserId(authUser), playlistId);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -64,5 +64,12 @@ public class PlaylistTrackController {
             @Valid @RequestBody PlaylistTrackReorderRequest request
     ) {
         return playlistTrackService.reorderTracks(authUser.userId(), playlistId, request);
+    }
+
+    private Long getUserId(AuthUser authUser) {
+        if (authUser == null) {
+            return null;
+        }
+        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
+++ b/src/main/java/com/tunesharehub/controller/PlaylistTrackController.java
@@ -44,7 +44,7 @@ public class PlaylistTrackController {
             @CurrentUser(required = false) AuthUser authUser,
             @PathVariable Long playlistId
     ) {
-        return playlistTrackService.getTracks(getUserId(authUser), playlistId);
+        return playlistTrackService.getTracks(AuthUser.userIdOrNull(authUser), playlistId);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -64,12 +64,5 @@ public class PlaylistTrackController {
             @Valid @RequestBody PlaylistTrackReorderRequest request
     ) {
         return playlistTrackService.reorderTracks(authUser.userId(), playlistId, request);
-    }
-
-    private Long getUserId(AuthUser authUser) {
-        if (authUser == null) {
-            return null;
-        }
-        return authUser.userId();
     }
 }

--- a/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
@@ -51,7 +51,7 @@ public interface PlaylistMapper {
 
     void decreaseLikeCount(@Param("playlistId") Long playlistId);
 
-    void increaseViewCount(@Param("playlistId") Long playlistId);
+    int increaseViewCount(@Param("playlistId") Long playlistId);
 
     Long findLikeCountById(@Param("playlistId") Long playlistId);
 }

--- a/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
+++ b/src/main/java/com/tunesharehub/mapper/PlaylistMapper.java
@@ -51,5 +51,7 @@ public interface PlaylistMapper {
 
     void decreaseLikeCount(@Param("playlistId") Long playlistId);
 
+    void increaseViewCount(@Param("playlistId") Long playlistId);
+
     Long findLikeCountById(@Param("playlistId") Long playlistId);
 }

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -51,6 +51,17 @@ public class PlaylistService {
         return toResponse(playlist);
     }
 
+    @Transactional
+    public PlaylistResponse getPlaylistDetail(Long loginUserId, Long playlistId) {
+        Playlist playlist = getExistingPlaylist(playlistId);
+        validateReadable(loginUserId, playlist);
+        if (shouldIncreaseViewCount(loginUserId, playlist)) {
+            playlistMapper.increaseViewCount(playlistId);
+            playlist.setViewCount(playlist.getViewCount() + 1);
+        }
+        return toResponse(playlist);
+    }
+
     @Transactional(readOnly = true)
     public List<PlaylistResponse> getMyPlaylists(Long userId, int page, int size) {
         int offset = page * size;
@@ -203,6 +214,10 @@ public class PlaylistService {
             return "";
         }
         return keyword.trim();
+    }
+
+    private boolean shouldIncreaseViewCount(Long loginUserId, Playlist playlist) {
+        return PUBLIC_YN_TRUE.equals(playlist.getPublicYn()) && !playlist.getUserId().equals(loginUserId);
     }
 
     private String normalizeSearchType(String searchType) {

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -56,8 +56,11 @@ public class PlaylistService {
         Playlist playlist = getExistingPlaylist(playlistId);
         validateReadable(loginUserId, playlist);
         if (shouldIncreaseViewCount(loginUserId, playlist)) {
-            playlistMapper.increaseViewCount(playlistId);
-            playlist.setViewCount(playlist.getViewCount() + 1);
+            int updatedCount = playlistMapper.increaseViewCount(playlistId);
+            if (updatedCount == 1) {
+                long currentViewCount = playlist.getViewCount() != null ? playlist.getViewCount() : 0L;
+                playlist.setViewCount(currentViewCount + 1);
+            }
         }
         return toResponse(playlist);
     }

--- a/src/main/resources/mappers/PlaylistMapper.xml
+++ b/src/main/resources/mappers/PlaylistMapper.xml
@@ -232,6 +232,14 @@
           AND DELETED_AT IS NULL
     </update>
 
+    <update id="increaseViewCount">
+        UPDATE PLAYLISTS
+        SET VIEW_COUNT = VIEW_COUNT + 1
+        WHERE PLAYLIST_ID = #{playlistId}
+          AND PUBLIC_YN = 'Y'
+          AND DELETED_AT IS NULL
+    </update>
+
     <select id="findLikeCountById" resultType="long">
         SELECT LIKE_COUNT
         FROM PLAYLISTS

--- a/src/test/java/com/tunesharehub/auth/AuthUserArgumentResolverTest.java
+++ b/src/test/java/com/tunesharehub/auth/AuthUserArgumentResolverTest.java
@@ -1,0 +1,49 @@
+package com.tunesharehub.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+class AuthUserArgumentResolverTest {
+
+    private final AuthUserArgumentResolver resolver = new AuthUserArgumentResolver();
+
+    @Test
+    void optionalCurrentUserReturnsNullWhenRequestHasNoAuthUser() throws Exception {
+        MethodParameter parameter = getParameter("optionalCurrentUser");
+        NativeWebRequest webRequest = new ServletWebRequest(new MockHttpServletRequest());
+
+        Object resolved = resolver.resolveArgument(parameter, null, webRequest, null);
+
+        assertThat(resolved).isNull();
+    }
+
+    @Test
+    void requiredCurrentUserRejectsMissingAuthUser() throws Exception {
+        MethodParameter parameter = getParameter("requiredCurrentUser");
+        NativeWebRequest webRequest = new ServletWebRequest(new MockHttpServletRequest());
+
+        assertThatThrownBy(() -> resolver.resolveArgument(parameter, null, webRequest, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("인증 사용자 정보가 필요합니다.");
+    }
+
+    @SuppressWarnings("unused")
+    void optionalCurrentUser(@CurrentUser(required = false) AuthUser authUser) {
+    }
+
+    @SuppressWarnings("unused")
+    void requiredCurrentUser(@CurrentUser AuthUser authUser) {
+    }
+
+    private MethodParameter getParameter(String methodName) throws NoSuchMethodException {
+        Method method = AuthUserArgumentResolverTest.class.getDeclaredMethod(methodName, AuthUser.class);
+        return new MethodParameter(method, 0);
+    }
+}

--- a/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
+++ b/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
@@ -41,6 +41,16 @@ class JwtInterceptorTest {
     }
 
     @Test
+    void publicPlaylistDetailWithTrailingSlashDoesNotRequireToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10/");
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
     void publicPlaylistTracksDoesNotRequireToken() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10/tracks");
 
@@ -58,6 +68,15 @@ class JwtInterceptorTest {
 
         assertThat(result).isTrue();
         verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
+    void malformedPublicPlaylistPathStillRequiresToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/latest");
+
+        assertThatThrownBy(() -> jwtInterceptor.preHandle(request, response, handler))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("인증 토큰이 필요합니다.");
     }
 
     @Test

--- a/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
+++ b/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
@@ -2,9 +2,11 @@ package com.tunesharehub.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -25,7 +27,50 @@ class JwtInterceptorTest {
         boolean result = jwtInterceptor.preHandle(request, response, handler);
 
         assertThat(result).isTrue();
-        verify(jwtProvider, never()).parseAccessToken(org.mockito.ArgumentMatchers.anyString());
+        verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
+    void publicPlaylistDetailDoesNotRequireToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10");
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
+    void publicPlaylistTracksDoesNotRequireToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10/tracks");
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
+    void publicPlaylistCommentsDoesNotRequireToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10/comments");
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        verify(jwtProvider, never()).parseAccessToken(anyString());
+    }
+
+    @Test
+    void publicEndpointParsesTokenWhenAuthorizationHeaderExists() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/playlists/10");
+        request.addHeader("Authorization", "Bearer access-token");
+        AuthUser authUser = new AuthUser(1L, "user@example.com", "alice", "USER");
+        when(jwtProvider.parseAccessToken("access-token")).thenReturn(authUser);
+
+        boolean result = jwtInterceptor.preHandle(request, response, handler);
+
+        assertThat(result).isTrue();
+        assertThat(request.getAttribute(JwtInterceptor.AUTH_USER_ATTRIBUTE)).isEqualTo(authUser);
     }
 
     @Test

--- a/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
@@ -2,6 +2,7 @@ package com.tunesharehub.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,6 +61,28 @@ class PlaylistServiceTest {
         assertThatThrownBy(() -> playlistService.getPublicPlaylists("", "title", "popular", 0, 20))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("정렬 값이 올바르지 않습니다.");
+    }
+
+    @Test
+    void getPlaylistDetailAllowsAnonymousPublicPlaylistAndIncreasesViewCount() {
+        Playlist playlist = publicPlaylist();
+        when(playlistMapper.findById(10L)).thenReturn(playlist);
+
+        PlaylistResponse response = playlistService.getPlaylistDetail(null, 10L);
+
+        verify(playlistMapper).increaseViewCount(10L);
+        assertThat(response.viewCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void getPlaylistDetailDoesNotIncreaseOwnerViewCount() {
+        Playlist playlist = publicPlaylist();
+        when(playlistMapper.findById(10L)).thenReturn(playlist);
+
+        PlaylistResponse response = playlistService.getPlaylistDetail(1L, 10L);
+
+        verify(playlistMapper, never()).increaseViewCount(10L);
+        assertThat(response.viewCount()).isZero();
     }
 
     private Playlist publicPlaylist() {

--- a/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
@@ -67,11 +67,37 @@ class PlaylistServiceTest {
     void getPlaylistDetailAllowsAnonymousPublicPlaylistAndIncreasesViewCount() {
         Playlist playlist = publicPlaylist();
         when(playlistMapper.findById(10L)).thenReturn(playlist);
+        when(playlistMapper.increaseViewCount(10L)).thenReturn(1);
 
         PlaylistResponse response = playlistService.getPlaylistDetail(null, 10L);
 
         verify(playlistMapper).increaseViewCount(10L);
         assertThat(response.viewCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void getPlaylistDetailHandlesNullViewCount() {
+        Playlist playlist = publicPlaylist();
+        playlist.setViewCount(null);
+        when(playlistMapper.findById(10L)).thenReturn(playlist);
+        when(playlistMapper.increaseViewCount(10L)).thenReturn(1);
+
+        PlaylistResponse response = playlistService.getPlaylistDetail(null, 10L);
+
+        verify(playlistMapper).increaseViewCount(10L);
+        assertThat(response.viewCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void getPlaylistDetailDoesNotIncreaseResponseViewCountWhenUpdateFails() {
+        Playlist playlist = publicPlaylist();
+        when(playlistMapper.findById(10L)).thenReturn(playlist);
+        when(playlistMapper.increaseViewCount(10L)).thenReturn(0);
+
+        PlaylistResponse response = playlistService.getPlaylistDetail(null, 10L);
+
+        verify(playlistMapper).increaseViewCount(10L);
+        assertThat(response.viewCount()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 공개 플레이리스트 상세, 트랙 목록, 댓글 목록 조회를 비로그인 사용자에게 허용
- 공개 GET 요청에 토큰이 있으면 기존처럼 사용자 정보를 파싱하도록 JWT 인터셉터 수정
- 공개 플레이리스트 상세 조회 시 비작성자/비로그인 조회에 대해 VIEW_COUNT 증가 처리
- optional @CurrentUser 지원과 관련 단위 테스트 추가

## Tests
- ./gradlew test
- git diff --check

Closes #15