### PR TITLE
[Auth][Backend] 현재 사용자 조회 API 구현

### DIFF
--- a/src/main/java/com/tunesharehub/controller/SessionController.java
+++ b/src/main/java/com/tunesharehub/controller/SessionController.java
@@ -1,0 +1,25 @@
+package com.tunesharehub.controller;
+
+import com.tunesharehub.auth.AuthUser;
+import com.tunesharehub.auth.CurrentUser;
+import com.tunesharehub.dto.UserSummaryResponse;
+import com.tunesharehub.service.AuthService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/session")
+public class SessionController {
+
+    private final AuthService authService;
+
+    public SessionController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/me")
+    public UserSummaryResponse getCurrentUser(@CurrentUser AuthUser authUser) {
+        return authService.getCurrentUser(authUser.userId());
+    }
+}

--- a/src/main/java/com/tunesharehub/service/AuthService.java
+++ b/src/main/java/com/tunesharehub/service/AuthService.java
@@ -71,7 +71,7 @@ public class AuthService {
         if (user == null) {
             throw new InvalidTokenException("유효하지 않은 access token입니다.");
         }
-        return new UserSummaryResponse(user.getUserId(), user.getEmail(), user.getNickname(), user.getRole());
+        return toUserSummaryResponse(toAuthUser(user));
     }
 
     private LoginResponse issueTokens(AuthUser authUser) {
@@ -82,7 +82,7 @@ public class AuthService {
         return new LoginResponse(
                 accessToken,
                 refreshToken,
-                new UserSummaryResponse(authUser.userId(), authUser.email(), authUser.nickname(), authUser.role())
+                toUserSummaryResponse(authUser)
         );
     }
 
@@ -98,6 +98,10 @@ public class AuthService {
 
     private AuthUser toAuthUser(User user) {
         return new AuthUser(user.getUserId(), user.getEmail(), user.getNickname(), user.getRole());
+    }
+
+    private UserSummaryResponse toUserSummaryResponse(AuthUser authUser) {
+        return new UserSummaryResponse(authUser.userId(), authUser.email(), authUser.nickname(), authUser.role());
     }
 
     private boolean isPasswordMatched(String password, String passwordHash) {

--- a/src/main/java/com/tunesharehub/service/AuthService.java
+++ b/src/main/java/com/tunesharehub/service/AuthService.java
@@ -65,6 +65,15 @@ public class AuthService {
         refreshTokenMapper.revokeActiveByTokenValue(refreshTokenValue);
     }
 
+    @Transactional(readOnly = true)
+    public UserSummaryResponse getCurrentUser(Long userId) {
+        User user = userMapper.findActiveById(userId);
+        if (user == null) {
+            throw new InvalidTokenException("유효하지 않은 access token입니다.");
+        }
+        return new UserSummaryResponse(user.getUserId(), user.getEmail(), user.getNickname(), user.getRole());
+    }
+
     private LoginResponse issueTokens(AuthUser authUser) {
         String accessToken = jwtProvider.createAccessToken(authUser);
         String refreshToken = jwtProvider.createRefreshToken(authUser);

--- a/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
+++ b/src/test/java/com/tunesharehub/auth/JwtInterceptorTest.java
@@ -103,6 +103,15 @@ class JwtInterceptorTest {
     }
 
     @Test
+    void sessionMeRequiresToken() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/session/me");
+
+        assertThatThrownBy(() -> jwtInterceptor.preHandle(request, response, handler))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("인증 토큰이 필요합니다.");
+    }
+
+    @Test
     void playlistCreateStillRequiresToken() {
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/playlists");
 

--- a/src/test/java/com/tunesharehub/service/AuthServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/AuthServiceTest.java
@@ -1,0 +1,61 @@
+package com.tunesharehub.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.tunesharehub.auth.InvalidTokenException;
+import com.tunesharehub.auth.JwtProvider;
+import com.tunesharehub.dto.UserSummaryResponse;
+import com.tunesharehub.entity.User;
+import com.tunesharehub.mapper.RefreshTokenMapper;
+import com.tunesharehub.mapper.UserMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserMapper userMapper;
+
+    @Mock
+    private RefreshTokenMapper refreshTokenMapper;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void getCurrentUserReturnsActiveUser() {
+        User user = activeUser();
+        when(userMapper.findActiveById(1L)).thenReturn(user);
+
+        UserSummaryResponse response = authService.getCurrentUser(1L);
+
+        assertThat(response).isEqualTo(new UserSummaryResponse(1L, "alice@example.com", "alice", "USER"));
+    }
+
+    @Test
+    void getCurrentUserRejectsMissingUser() {
+        when(userMapper.findActiveById(1L)).thenReturn(null);
+
+        assertThatThrownBy(() -> authService.getCurrentUser(1L))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage("유효하지 않은 access token입니다.");
+    }
+
+    private User activeUser() {
+        User user = new User();
+        user.setUserId(1L);
+        user.setEmail("alice@example.com");
+        user.setNickname("alice");
+        user.setRole("USER");
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary
- GET /api/session/me API 추가
- JWT 인증 사용자의 active USERS 정보를 다시 조회해 UserSummaryResponse 반환
- 삭제/비활성 사용자 토큰은 401 INVALID_TOKEN 처리
- /api/session/me 인증 필수 인터셉터 테스트 추가

## Tests
- ./gradlew test
- git diff --check

Closes #23