### PR TITLE
[Frontend] 공개 플레이리스트 목록 화면 구현

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -9,5 +9,5 @@ export function getPublicPlaylists({ keyword = '', searchType = 'title', sort = 
     size: String(size),
   })
 
-  return apiRequest(`/api/playlists?${params.toString()}`)
+  return apiRequest(`/api/playlists?${params.toString()}`, { skipAuth: true })
 }

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -1,0 +1,13 @@
+import { apiRequest } from './client.js'
+
+export function getPublicPlaylists({ keyword = '', searchType = 'title', sort = 'latest', page = 0, size = 10 } = {}) {
+  const params = new URLSearchParams({
+    keyword,
+    searchType,
+    sort,
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/playlists?${params.toString()}`)
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,5 +1,8 @@
+import { useEffect, useMemo, useState } from 'react'
 import { AppShell } from '../components/layout/AppShell.jsx'
+import { Button } from '../components/common/Button.jsx'
 import { EmptyState } from '../components/common/EmptyState.jsx'
+import { getPublicPlaylists } from '../api/playlistApi.js'
 
 const dashboardItems = [
   {
@@ -22,7 +25,98 @@ const dashboardItems = [
   },
 ]
 
+const searchTypeOptions = [
+  { value: 'title', label: '제목' },
+  { value: 'author', label: '작성자' },
+]
+
+const sortOptions = [
+  { value: 'latest', label: '최신순' },
+  { value: 'view', label: '조회순' },
+  { value: 'like', label: '좋아요순' },
+  { value: 'comment', label: '댓글순' },
+]
+
+const sizeOptions = [10, 20, 50]
+
 export function HomePage() {
+  const [keywordInput, setKeywordInput] = useState('')
+  const [filters, setFilters] = useState({
+    keyword: '',
+    searchType: 'title',
+    sort: 'latest',
+    size: 10,
+  })
+  const [page, setPage] = useState(0)
+  const [playlists, setPlaylists] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(true)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    let isActive = true
+
+    Promise.resolve().then(async () => {
+      if (!isActive) {
+        return
+      }
+
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const response = await getPublicPlaylists({
+          ...filters,
+          page,
+        })
+
+        if (!isActive) {
+          return
+        }
+
+        setPlaylists((current) => (page === 0 ? response : [...current, ...response]))
+        setHasMore(response.length === filters.size)
+      } catch (error) {
+        if (isActive) {
+          setErrorMessage(error.message ?? '공개 플레이리스트를 불러오지 못했습니다.')
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false)
+        }
+      }
+    })
+
+    return () => {
+      isActive = false
+    }
+  }, [filters, page])
+
+  const activeFilterLabel = useMemo(() => {
+    const sortLabel = sortOptions.find((option) => option.value === filters.sort)?.label
+    const typeLabel = searchTypeOptions.find((option) => option.value === filters.searchType)?.label
+    return filters.keyword ? `${typeLabel} 검색 · ${sortLabel}` : sortLabel
+  }, [filters.keyword, filters.searchType, filters.sort])
+
+  function handleSearchSubmit(event) {
+    event.preventDefault()
+    setPage(0)
+    setHasMore(true)
+    setFilters((current) => ({
+      ...current,
+      keyword: keywordInput.trim(),
+    }))
+  }
+
+  function handleFilterChange(name, value) {
+    setPage(0)
+    setHasMore(true)
+    setFilters((current) => ({
+      ...current,
+      [name]: name === 'size' ? Number(value) : value,
+    }))
+  }
+
   return (
     <AppShell>
       <main className="workspace">
@@ -44,15 +138,89 @@ export function HomePage() {
         </section>
 
         <section className="content-grid">
-          <div id="public-playlists" className="panel">
+          <div id="public-playlists" className="panel panel-wide">
             <div className="panel-header">
               <h2>공개 플레이리스트</h2>
-              <span>latest</span>
+              <span>{activeFilterLabel}</span>
             </div>
-            <EmptyState
-              title="표시할 플레이리스트가 없습니다"
-              description="새로운 공개 플레이리스트를 기다리고 있습니다."
-            />
+
+            <form className="playlist-toolbar" onSubmit={handleSearchSubmit}>
+              <label>
+                <span>검색</span>
+                <input
+                  type="search"
+                  value={keywordInput}
+                  onChange={(event) => setKeywordInput(event.target.value)}
+                  placeholder="플레이리스트 검색"
+                />
+              </label>
+
+              <label>
+                <span>대상</span>
+                <select
+                  value={filters.searchType}
+                  onChange={(event) => handleFilterChange('searchType', event.target.value)}
+                >
+                  {searchTypeOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label>
+                <span>정렬</span>
+                <select value={filters.sort} onChange={(event) => handleFilterChange('sort', event.target.value)}>
+                  {sortOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label>
+                <span>개수</span>
+                <select value={filters.size} onChange={(event) => handleFilterChange('size', event.target.value)}>
+                  {sizeOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}개
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <Button className="button-primary" disabled={isLoading} type="submit">
+                검색
+              </Button>
+            </form>
+
+            {errorMessage ? <p className="panel-error">{errorMessage}</p> : null}
+
+            {playlists.length > 0 ? (
+              <>
+                <div className="playlist-list" aria-live="polite">
+                  {playlists.map((playlist) => (
+                    <PlaylistCard key={playlist.playlistId} playlist={playlist} />
+                  ))}
+                </div>
+                <div className="list-actions">
+                  <Button className="button-secondary" disabled={isLoading || !hasMore} onClick={() => setPage(page + 1)}>
+                    {isLoading ? '불러오는 중' : hasMore ? '더 보기' : '마지막 목록'}
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <EmptyState
+                title={isLoading ? '플레이리스트를 불러오는 중입니다' : '표시할 플레이리스트가 없습니다'}
+                description={
+                  filters.keyword
+                    ? '검색 조건에 맞는 공개 플레이리스트가 없습니다.'
+                    : '새로운 공개 플레이리스트를 기다리고 있습니다.'
+                }
+              />
+            )}
           </div>
 
           <div id="my-playlists" className="panel">
@@ -69,4 +237,31 @@ export function HomePage() {
       </main>
     </AppShell>
   )
+}
+
+function PlaylistCard({ playlist }) {
+  return (
+    <article className="playlist-card">
+      <div className="playlist-cover" aria-hidden="true">
+        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title.slice(0, 2)}</span>}
+      </div>
+
+      <div className="playlist-content">
+        <div>
+          <h3>{playlist.title}</h3>
+          <p>{playlist.description || '설명이 없는 공개 플레이리스트입니다.'}</p>
+        </div>
+        <div className="playlist-meta">
+          <span>{playlist.userNickname}</span>
+          <span>조회 {formatCount(playlist.viewCount)}</span>
+          <span>좋아요 {formatCount(playlist.likeCount)}</span>
+          <span>댓글 {formatCount(playlist.commentCount)}</span>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function formatCount(value) {
+  return Number(value ?? 0).toLocaleString('ko-KR')
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -39,6 +39,10 @@ const sortOptions = [
 
 const sizeOptions = [10, 20, 50]
 
+const filterValueParsers = {
+  size: Number,
+}
+
 export function HomePage() {
   const [keywordInput, setKeywordInput] = useState('')
   const [filters, setFilters] = useState({
@@ -56,11 +60,7 @@ export function HomePage() {
   useEffect(() => {
     let isActive = true
 
-    Promise.resolve().then(async () => {
-      if (!isActive) {
-        return
-      }
-
+    async function fetchPlaylists() {
       setIsLoading(true)
       setErrorMessage('')
 
@@ -74,8 +74,9 @@ export function HomePage() {
           return
         }
 
-        setPlaylists((current) => (page === 0 ? response : [...current, ...response]))
-        setHasMore(response.length === filters.size)
+        const data = Array.isArray(response) ? response : []
+        setPlaylists((current) => (page === 0 ? data : [...current, ...data]))
+        setHasMore(data.length === filters.size)
       } catch (error) {
         if (isActive) {
           setErrorMessage(error.message ?? '공개 플레이리스트를 불러오지 못했습니다.')
@@ -85,7 +86,9 @@ export function HomePage() {
           setIsLoading(false)
         }
       }
-    })
+    }
+
+    fetchPlaylists()
 
     return () => {
       isActive = false
@@ -113,7 +116,7 @@ export function HomePage() {
     setHasMore(true)
     setFilters((current) => ({
       ...current,
-      [name]: name === 'size' ? Number(value) : value,
+      [name]: filterValueParsers[name]?.(value) ?? value,
     }))
   }
 
@@ -243,7 +246,7 @@ function PlaylistCard({ playlist }) {
   return (
     <article className="playlist-card">
       <div className="playlist-cover" aria-hidden="true">
-        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title.slice(0, 2)}</span>}
+        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title?.slice(0, 2) ?? ''}</span>}
       </div>
 
       <div className="playlist-content">

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -15,6 +15,7 @@
 
 .button:focus-visible,
 input:focus-visible,
+select:focus-visible,
 a:focus-visible {
   outline: 2px solid var(--color-cyan);
   outline-offset: 3px;
@@ -272,6 +273,10 @@ a:focus-visible {
   padding: 22px;
 }
 
+.panel-wide {
+  grid-column: 1 / -1;
+}
+
 .panel-header {
   display: flex;
   align-items: center;
@@ -290,6 +295,113 @@ a:focus-visible {
   color: var(--color-subtle);
   font-family: var(--font-mono);
   font-size: 12px;
+}
+
+.playlist-toolbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 140px 140px 120px auto;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.playlist-toolbar label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.playlist-toolbar input,
+.playlist-toolbar select {
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0 12px;
+  color: var(--color-text);
+  background: var(--color-background);
+}
+
+.panel-error {
+  margin: 0 0 14px;
+  color: var(--color-rose);
+  font-size: 14px;
+}
+
+.playlist-list {
+  display: grid;
+  gap: 12px;
+}
+
+.playlist-card {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--color-surface-raised);
+}
+
+.playlist-cover {
+  display: grid;
+  overflow: hidden;
+  width: 92px;
+  height: 92px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background:
+    linear-gradient(135deg, rgba(34, 197, 94, 0.95), rgba(56, 189, 248, 0.78)),
+    var(--color-green);
+  font-weight: 800;
+}
+
+.playlist-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.playlist-content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.playlist-content h3 {
+  margin: 0 0 8px;
+  overflow-wrap: anywhere;
+  font-size: 18px;
+  letter-spacing: 0;
+}
+
+.playlist-content p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.playlist-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--color-subtle);
+  font-size: 13px;
+}
+
+.list-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
 }
 
 .empty-state {
@@ -320,8 +432,16 @@ a:focus-visible {
   .login-panel,
   .app-shell,
   .dashboard-grid,
-  .content-grid {
+  .content-grid,
+  .playlist-toolbar,
+  .playlist-card {
     grid-template-columns: 1fr;
+  }
+
+  .playlist-cover {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 7;
   }
 
   .login-copy {


### PR DESCRIPTION
## 작업 내용
- 공개 플레이리스트 목록 API 연동 함수를 추가했습니다.
- 홈 화면 공개 플레이리스트 패널에 검색어, 검색 대상, 정렬, 페이지 크기 컨트롤을 추가했습니다.
- 목록 카드, 로딩/에러/빈 목록 상태, 더 보기 동작을 구현했습니다.
- Vite 개발 서버 캐시인 frontend/.vite를 gitignore에 추가했습니다.

## 검증
- npm run lint
- npm run build
- git diff --check
- curl -I http://127.0.0.1:5174/

Closes #27