### PR TITLE
[Frontend] 플레이리스트 상세 화면 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react'
 import { AuthProvider } from './contexts/AuthProvider.jsx'
 import { useAuth } from './hooks/useAuth.js'
 import { HomePage } from './pages/HomePage.jsx'
 import { LoginPage } from './pages/LoginPage.jsx'
+import { PlaylistDetailPage } from './pages/PlaylistDetailPage.jsx'
 
 function App() {
   return (
@@ -12,7 +14,17 @@ function App() {
 }
 
 function AppContent() {
-  const { isAuthenticated, isBootstrapping } = useAuth()
+  const { isAuthenticated, isBootstrapping, user } = useAuth()
+  const [selectedPlaylistId, setSelectedPlaylistId] = useState(() => getPlaylistIdFromHash())
+
+  useEffect(() => {
+    function handleHashChange() {
+      setSelectedPlaylistId(getPlaylistIdFromHash())
+    }
+
+    window.addEventListener('hashchange', handleHashChange)
+    return () => window.removeEventListener('hashchange', handleHashChange)
+  }, [])
 
   if (isBootstrapping) {
     return (
@@ -28,7 +40,36 @@ function AppContent() {
     return <LoginPage />
   }
 
-  return <HomePage />
+  if (selectedPlaylistId) {
+    return (
+      <PlaylistDetailPage
+        currentUser={user}
+        onBack={() => {
+          window.location.hash = 'public-playlists'
+          setSelectedPlaylistId(null)
+        }}
+        onSelectPlaylist={(playlistId) => {
+          window.location.hash = `playlist/${playlistId}`
+          setSelectedPlaylistId(playlistId)
+        }}
+        playlistId={selectedPlaylistId}
+      />
+    )
+  }
+
+  return (
+    <HomePage
+      onSelectPlaylist={(playlistId) => {
+        window.location.hash = `playlist/${playlistId}`
+        setSelectedPlaylistId(playlistId)
+      }}
+    />
+  )
+}
+
+function getPlaylistIdFromHash() {
+  const match = window.location.hash.match(/^#playlist\/([1-9]\d*)$/)
+  return match ? Number(match[1]) : null
 }
 
 export default App

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -68,7 +68,7 @@ function AppContent() {
 }
 
 function getPlaylistIdFromHash() {
-  const match = window.location.hash.match(/^#playlist\/([1-9]\d*)$/)
+  const match = window.location.hash.match(/^#playlist\/(\d+)$/)
   return match ? Number(match[1]) : null
 }
 

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -13,11 +13,11 @@ export function getPublicPlaylists({ keyword = '', searchType = 'title', sort = 
 }
 
 export function getPlaylist(playlistId) {
-  return apiRequest(`/api/playlists/${playlistId}`, { skipAuth: true })
+  return apiRequest(`/api/playlists/${playlistId}`)
 }
 
 export function getPlaylistTracks(playlistId) {
-  return apiRequest(`/api/playlists/${playlistId}/tracks`, { skipAuth: true })
+  return apiRequest(`/api/playlists/${playlistId}/tracks`)
 }
 
 export function getPlaylistComments(playlistId, { page = 0, size = 20 } = {}) {
@@ -26,7 +26,7 @@ export function getPlaylistComments(playlistId, { page = 0, size = 20 } = {}) {
     size: String(size),
   })
 
-  return apiRequest(`/api/playlists/${playlistId}/comments?${params.toString()}`, { skipAuth: true })
+  return apiRequest(`/api/playlists/${playlistId}/comments?${params.toString()}`)
 }
 
 export function getSimilarPlaylists(playlistId, { size = 6 } = {}) {
@@ -34,5 +34,5 @@ export function getSimilarPlaylists(playlistId, { size = 6 } = {}) {
     size: String(size),
   })
 
-  return apiRequest(`/api/playlists/${playlistId}/similar?${params.toString()}`, { skipAuth: true })
+  return apiRequest(`/api/playlists/${playlistId}/similar?${params.toString()}`)
 }

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -11,3 +11,28 @@ export function getPublicPlaylists({ keyword = '', searchType = 'title', sort = 
 
   return apiRequest(`/api/playlists?${params.toString()}`, { skipAuth: true })
 }
+
+export function getPlaylist(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}`, { skipAuth: true })
+}
+
+export function getPlaylistTracks(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}/tracks`, { skipAuth: true })
+}
+
+export function getPlaylistComments(playlistId, { page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/playlists/${playlistId}/comments?${params.toString()}`, { skipAuth: true })
+}
+
+export function getSimilarPlaylists(playlistId, { size = 6 } = {}) {
+  const params = new URLSearchParams({
+    size: String(size),
+  })
+
+  return apiRequest(`/api/playlists/${playlistId}/similar?${params.toString()}`, { skipAuth: true })
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -43,7 +43,7 @@ const filterValueParsers = {
   size: Number,
 }
 
-export function HomePage() {
+export function HomePage({ onSelectPlaylist }) {
   const [keywordInput, setKeywordInput] = useState('')
   const [filters, setFilters] = useState({
     keyword: '',
@@ -205,7 +205,7 @@ export function HomePage() {
               <>
                 <div className="playlist-list" aria-live="polite">
                   {playlists.map((playlist) => (
-                    <PlaylistCard key={playlist.playlistId} playlist={playlist} />
+                    <PlaylistCard key={playlist.playlistId} onSelectPlaylist={onSelectPlaylist} playlist={playlist} />
                   ))}
                 </div>
                 <div className="list-actions">
@@ -242,9 +242,18 @@ export function HomePage() {
   )
 }
 
-function PlaylistCard({ playlist }) {
+function PlaylistCard({ onSelectPlaylist, playlist }) {
+  function handleClick(event) {
+    if (!onSelectPlaylist) {
+      return
+    }
+
+    event.preventDefault()
+    onSelectPlaylist(playlist.playlistId)
+  }
+
   return (
-    <article className="playlist-card">
+    <a className="playlist-card" href={`#playlist/${playlist.playlistId}`} onClick={handleClick}>
       <div className="playlist-cover" aria-hidden="true">
         {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title?.slice(0, 2) ?? ''}</span>}
       </div>
@@ -261,7 +270,7 @@ function PlaylistCard({ playlist }) {
           <span>댓글 {formatCount(playlist.commentCount)}</span>
         </div>
       </div>
-    </article>
+    </a>
   )
 }
 

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -24,9 +24,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       try {
         const [playlist, tracks, comments, similarPlaylists] = await Promise.all([
           getPlaylist(playlistId),
-          getPlaylistTracks(playlistId),
-          getPlaylistComments(playlistId, { size: 20 }),
-          getSimilarPlaylists(playlistId),
+          getPlaylistTracks(playlistId).catch(() => []),
+          getPlaylistComments(playlistId, { size: 20 }).catch(() => []),
+          getSimilarPlaylists(playlistId).catch(() => []),
         ])
 
         if (!isActive) {

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getPlaylist, getPlaylistComments, getPlaylistTracks, getSimilarPlaylists } from '../api/playlistApi.js'
+import { Button } from '../components/common/Button.jsx'
+import { EmptyState } from '../components/common/EmptyState.jsx'
+import { AppShell } from '../components/layout/AppShell.jsx'
+
+export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, playlistId }) {
+  const [detail, setDetail] = useState({
+    playlist: null,
+    tracks: [],
+    comments: [],
+    similarPlaylists: [],
+  })
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    let isActive = true
+
+    async function fetchDetail() {
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const [playlist, tracks, comments, similarPlaylists] = await Promise.all([
+          getPlaylist(playlistId),
+          getPlaylistTracks(playlistId),
+          getPlaylistComments(playlistId, { size: 20 }),
+          getSimilarPlaylists(playlistId),
+        ])
+
+        if (!isActive) {
+          return
+        }
+
+        setDetail({
+          playlist,
+          tracks: Array.isArray(tracks) ? tracks : [],
+          comments: Array.isArray(comments) ? comments : [],
+          similarPlaylists: Array.isArray(similarPlaylists) ? similarPlaylists : [],
+        })
+      } catch (error) {
+        if (isActive) {
+          setErrorMessage(error.message ?? '플레이리스트 상세를 불러오지 못했습니다.')
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchDetail()
+
+    return () => {
+      isActive = false
+    }
+  }, [playlistId])
+
+  const { comments, playlist, similarPlaylists, tracks } = detail
+  const isOwner = currentUser?.userId === playlist?.userId
+  const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) ?? 'TS', [playlist?.title])
+
+  return (
+    <AppShell>
+      <main className="workspace detail-workspace">
+        <section className="workspace-header">
+          <div>
+            <p className="eyebrow">Playlist Detail</p>
+            <h1>{playlist?.title ?? '플레이리스트 상세'}</h1>
+          </div>
+          <Button className="button-secondary" onClick={onBack}>
+            목록으로
+          </Button>
+        </section>
+
+        {errorMessage ? <p className="panel-error detail-error">{errorMessage}</p> : null}
+
+        {isLoading ? (
+          <section className="panel detail-loading">
+            <EmptyState title="상세 정보를 불러오는 중입니다" description="수록곡과 댓글을 함께 준비하고 있습니다." />
+          </section>
+        ) : playlist ? (
+          <>
+            <section className="detail-hero">
+              <div className="detail-cover" aria-hidden="true">
+                {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{heroInitials}</span>}
+              </div>
+
+              <div className="detail-copy">
+                <div className="detail-title-row">
+                  <div>
+                    <p className="eyebrow">{playlist.publicYn ? 'Public Playlist' : 'Private Playlist'}</p>
+                    <h2>{playlist.title}</h2>
+                  </div>
+                  {isOwner ? <span className="owner-pill">내 플레이리스트</span> : null}
+                </div>
+
+                <p className="detail-description">{playlist.description || '설명이 없는 공개 플레이리스트입니다.'}</p>
+
+                <div className="detail-meta">
+                  <span>{playlist.userNickname}</span>
+                  <span>생성 {formatDate(playlist.createdAt)}</span>
+                  {playlist.originUserNickname ? <span>원작자 {playlist.originUserNickname}</span> : null}
+                </div>
+
+                <div className="detail-stats" aria-label="플레이리스트 통계">
+                  <Stat label="조회" value={playlist.viewCount} />
+                  <Stat label="좋아요" value={playlist.likeCount} />
+                  <Stat label="댓글" value={playlist.commentCount} />
+                  <Stat label="복사" value={playlist.copyCount} />
+                </div>
+              </div>
+            </section>
+
+            <section className="detail-grid">
+              <div className="panel detail-panel">
+                <div className="panel-header">
+                  <h2>수록곡</h2>
+                  <span>{tracks.length} tracks</span>
+                </div>
+                {tracks.length > 0 ? (
+                  <div className="track-list">
+                    {tracks.map((track) => (
+                      <TrackRow key={track.playlistTrackId} track={track} />
+                    ))}
+                  </div>
+                ) : (
+                  <EmptyState title="수록곡이 없습니다" description="아직 이 플레이리스트에 담긴 곡이 없습니다." />
+                )}
+              </div>
+
+              <div className="panel detail-panel">
+                <div className="panel-header">
+                  <h2>댓글</h2>
+                  <span>{comments.length} comments</span>
+                </div>
+                {comments.length > 0 ? (
+                  <div className="comment-list">
+                    {comments.map((comment) => (
+                      <CommentItem comment={comment} key={comment.commentId} />
+                    ))}
+                  </div>
+                ) : (
+                  <EmptyState title="댓글이 없습니다" description="첫 반응을 기다리고 있습니다." />
+                )}
+              </div>
+            </section>
+
+            <section className="panel detail-panel">
+              <div className="panel-header">
+                <h2>유사 플레이리스트</h2>
+                <span>{similarPlaylists.length} similar</span>
+              </div>
+              {similarPlaylists.length > 0 ? (
+                <div className="similar-list">
+                  {similarPlaylists.map((similarPlaylist) => (
+                    <button
+                      className="similar-card"
+                      key={similarPlaylist.playlistId}
+                      onClick={() => onSelectPlaylist(similarPlaylist.playlistId)}
+                      type="button"
+                    >
+                      <strong>{similarPlaylist.title}</strong>
+                      <span>{similarPlaylist.userNickname}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <EmptyState title="아직 유사한 플레이리스트가 없습니다" description="공통 수록곡이 생기면 여기에 표시됩니다." />
+              )}
+            </section>
+          </>
+        ) : null}
+      </main>
+    </AppShell>
+  )
+}
+
+function Stat({ label, value }) {
+  return (
+    <span>
+      <strong>{formatCount(value)}</strong>
+      {label}
+    </span>
+  )
+}
+
+function TrackRow({ track }) {
+  return (
+    <article className="track-row">
+      <div className="track-cover" aria-hidden="true">
+        {track.albumImageUrl ? <img src={track.albumImageUrl} alt="" /> : <span>{track.title?.slice(0, 1) ?? 'T'}</span>}
+      </div>
+      <div className="track-main">
+        <strong>{track.title}</strong>
+        <span>{track.artistName}</span>
+      </div>
+      <span className="track-album">{track.albumName}</span>
+      <span className="track-duration">{formatDuration(track.durationMs)}</span>
+    </article>
+  )
+}
+
+function CommentItem({ comment }) {
+  return (
+    <article className="comment-item">
+      <div>
+        <strong>{comment.userNickname}</strong>
+        <span>{formatDate(comment.createdAt)}</span>
+      </div>
+      <p>{comment.content}</p>
+    </article>
+  )
+}
+
+function formatCount(value) {
+  return Number(value ?? 0).toLocaleString('ko-KR')
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '-'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return '-'
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function formatDuration(durationMs) {
+  const totalSeconds = Math.floor(Number(durationMs ?? 0) / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
+}

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -59,7 +59,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
 
   const { comments, playlist, similarPlaylists, tracks } = detail
   const isOwner = currentUser?.userId === playlist?.userId
-  const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) ?? 'TS', [playlist?.title])
+  const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) || 'TS', [playlist?.title])
 
   return (
     <AppShell>
@@ -155,15 +155,22 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
               {similarPlaylists.length > 0 ? (
                 <div className="similar-list">
                   {similarPlaylists.map((similarPlaylist) => (
-                    <button
+                    <a
                       className="similar-card"
+                      href={`#playlist/${similarPlaylist.playlistId}`}
                       key={similarPlaylist.playlistId}
-                      onClick={() => onSelectPlaylist(similarPlaylist.playlistId)}
-                      type="button"
+                      onClick={(event) => {
+                        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+                          return
+                        }
+
+                        event.preventDefault()
+                        onSelectPlaylist(similarPlaylist.playlistId)
+                      }}
                     >
                       <strong>{similarPlaylist.title}</strong>
                       <span>{similarPlaylist.userNickname}</span>
-                    </button>
+                    </a>
                   ))}
                 </div>
               ) : (

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -631,6 +631,7 @@ a:focus-visible {
   color: var(--color-text);
   background: var(--color-surface-raised);
   text-align: left;
+  text-decoration: none;
   cursor: pointer;
 }
 

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -342,7 +342,14 @@ a:focus-visible {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 14px;
+  color: var(--color-text);
   background: var(--color-surface-raised);
+  text-align: left;
+  text-decoration: none;
+}
+
+.playlist-card:hover {
+  border-color: rgba(56, 189, 248, 0.62);
 }
 
 .playlist-cover {
@@ -404,6 +411,248 @@ a:focus-visible {
   margin-top: 16px;
 }
 
+.detail-workspace {
+  display: grid;
+  gap: 16px;
+}
+
+.detail-error {
+  margin: 0;
+}
+
+.detail-loading {
+  min-height: 360px;
+}
+
+.detail-hero {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+  gap: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 22px;
+  background: var(--color-surface);
+}
+
+.detail-cover {
+  display: grid;
+  overflow: hidden;
+  min-height: 320px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background:
+    linear-gradient(135deg, rgba(34, 197, 94, 0.95), rgba(56, 189, 248, 0.76)),
+    var(--color-green);
+  font-size: 56px;
+  font-weight: 800;
+}
+
+.detail-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.detail-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.detail-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-title-row h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 36px;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.owner-pill {
+  flex: 0 0 auto;
+  border: 1px solid rgba(56, 189, 248, 0.44);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: var(--color-cyan);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.detail-description {
+  max-width: 760px;
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+.detail-meta,
+.detail-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+}
+
+.detail-meta {
+  color: var(--color-subtle);
+  font-size: 14px;
+}
+
+.detail-stats span {
+  min-width: 92px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--color-muted);
+  background: var(--color-surface-raised);
+  font-size: 12px;
+}
+
+.detail-stats strong {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--color-text);
+  font-size: 20px;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  gap: 16px;
+}
+
+.detail-panel {
+  min-height: 240px;
+}
+
+.track-list,
+.comment-list,
+.similar-list {
+  display: grid;
+  gap: 10px;
+}
+
+.track-row {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr) minmax(120px, 0.8fr) 48px;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-surface-raised);
+}
+
+.track-cover {
+  display: grid;
+  overflow: hidden;
+  width: 56px;
+  height: 56px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background: var(--color-cyan);
+  font-weight: 800;
+}
+
+.track-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.track-main {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.track-main strong,
+.track-album {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.track-main span,
+.track-album,
+.track-duration {
+  color: var(--color-subtle);
+  font-size: 13px;
+}
+
+.track-duration {
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+.comment-item {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 14px;
+  background: var(--color-surface-raised);
+}
+
+.comment-item div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--color-subtle);
+  font-size: 13px;
+}
+
+.comment-item strong {
+  color: var(--color-text);
+}
+
+.comment-item p {
+  margin: 10px 0 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.similar-list {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.similar-card {
+  min-height: 92px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 14px;
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+  text-align: left;
+  cursor: pointer;
+}
+
+.similar-card:hover {
+  border-color: rgba(34, 197, 94, 0.62);
+}
+
+.similar-card strong,
+.similar-card span {
+  display: block;
+}
+
+.similar-card strong {
+  overflow-wrap: anywhere;
+}
+
+.similar-card span {
+  margin-top: 8px;
+  color: var(--color-subtle);
+  font-size: 13px;
+}
+
 .empty-state {
   display: grid;
   min-height: 180px;
@@ -433,15 +682,32 @@ a:focus-visible {
   .app-shell,
   .dashboard-grid,
   .content-grid,
+  .detail-grid,
+  .detail-hero,
   .playlist-toolbar,
-  .playlist-card {
+  .playlist-card,
+  .similar-list,
+  .track-row {
     grid-template-columns: 1fr;
   }
 
+  .detail-cover,
   .playlist-cover {
     width: 100%;
     height: auto;
     aspect-ratio: 16 / 7;
+  }
+
+  .detail-cover {
+    min-height: auto;
+  }
+
+  .detail-title-row {
+    flex-direction: column;
+  }
+
+  .track-duration {
+    text-align: left;
   }
 
   .login-copy {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -34,7 +34,8 @@ body {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 


### PR DESCRIPTION
## 작업 내용
- Closes #29
- 플레이리스트 상세, 수록곡, 댓글, 유사 플레이리스트 조회 API 클라이언트를 추가했습니다.
- 홈 공개 플레이리스트 카드에서 hash 기반 상세 화면으로 이동하는 흐름을 추가했습니다.
- 상세 화면에 커버, 제목, 작성자, 설명, 통계, 수록곡 목록, 댓글 목록, 유사 플레이리스트 영역을 표시했습니다.
- 상세 API는 로그인 사용자 컨텍스트를 유지해 소유자 조회 시 view count가 잘못 증가하지 않도록 했습니다.

## 작업 단위 커밋
- feat(frontend): add playlist detail API clients
- feat(frontend): add playlist detail screen
- fix(frontend): preserve auth context for playlist detail

## 코드리뷰
- main 대비 diff를 읽고 API 인증 컨텍스트를 보정했습니다.
- 공개 목록 API만 skipAuth를 유지하고, 상세/트랙/댓글/유사 목록은 auth context를 보존합니다.

## 검증
- npm run lint
- npm run build
- git diff --check origin/main