### PR TITLE
[Frontend] 플레이리스트 상세 댓글·좋아요 상호작용 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,11 +15,11 @@ function App() {
 
 function AppContent() {
   const { isAuthenticated, isBootstrapping, user } = useAuth()
-  const [selectedPlaylistId, setSelectedPlaylistId] = useState(() => getPlaylistIdFromHash())
+  const [hashState, setHashState] = useState(() => getHashState())
 
   useEffect(() => {
     function handleHashChange() {
-      setSelectedPlaylistId(getPlaylistIdFromHash())
+      setHashState(getHashState())
     }
 
     window.addEventListener('hashchange', handleHashChange)
@@ -36,23 +36,23 @@ function AppContent() {
     )
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated && hashState.isLoginRoute) {
     return <LoginPage />
   }
 
-  if (selectedPlaylistId) {
+  if (hashState.selectedPlaylistId) {
     return (
       <PlaylistDetailPage
         currentUser={user}
         onBack={() => {
           window.location.hash = 'public-playlists'
-          setSelectedPlaylistId(null)
+          setHashState(getHashState())
         }}
         onSelectPlaylist={(playlistId) => {
           window.location.hash = `playlist/${playlistId}`
-          setSelectedPlaylistId(playlistId)
+          setHashState(getHashState())
         }}
-        playlistId={selectedPlaylistId}
+        playlistId={hashState.selectedPlaylistId}
       />
     )
   }
@@ -61,15 +61,18 @@ function AppContent() {
     <HomePage
       onSelectPlaylist={(playlistId) => {
         window.location.hash = `playlist/${playlistId}`
-        setSelectedPlaylistId(playlistId)
+        setHashState(getHashState())
       }}
     />
   )
 }
 
-function getPlaylistIdFromHash() {
+function getHashState() {
   const match = window.location.hash.match(/^#playlist\/(\d+)$/)
-  return match ? Number(match[1]) : null
+  return {
+    isLoginRoute: window.location.hash === '#login',
+    selectedPlaylistId: match ? Number(match[1]) : null,
+  }
 }
 
 export default App

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,11 +46,9 @@ function AppContent() {
         currentUser={user}
         onBack={() => {
           window.location.hash = 'public-playlists'
-          setHashState(getHashState())
         }}
         onSelectPlaylist={(playlistId) => {
           window.location.hash = `playlist/${playlistId}`
-          setHashState(getHashState())
         }}
         playlistId={hashState.selectedPlaylistId}
       />
@@ -61,7 +59,6 @@ function AppContent() {
     <HomePage
       onSelectPlaylist={(playlistId) => {
         window.location.hash = `playlist/${playlistId}`
-        setHashState(getHashState())
       }}
     />
   )

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -36,3 +36,28 @@ export function getSimilarPlaylists(playlistId, { size = 6 } = {}) {
 
   return apiRequest(`/api/playlists/${playlistId}/similar?${params.toString()}`)
 }
+
+export function createPlaylistComment(playlistId, content) {
+  return apiRequest(`/api/playlists/${playlistId}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  })
+}
+
+export function deletePlaylistComment(commentId) {
+  return apiRequest(`/api/comments/${commentId}`, {
+    method: 'DELETE',
+  })
+}
+
+export function likePlaylist(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}/likes`, {
+    method: 'POST',
+  })
+}
+
+export function unlikePlaylist(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}/likes`, {
+    method: 'DELETE',
+  })
+}

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -37,6 +37,15 @@ export function getSimilarPlaylists(playlistId, { size = 6 } = {}) {
   return apiRequest(`/api/playlists/${playlistId}/similar?${params.toString()}`)
 }
 
+export function getLikedPlaylists({ page = 0, size = 100 } = {}) {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/me/liked-playlists?${params.toString()}`)
+}
+
 export function createPlaylistComment(playlistId, content) {
   return apiRequest(`/api/playlists/${playlistId}/comments`, {
     method: 'POST',

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -46,6 +46,28 @@ export function getLikedPlaylists({ page = 0, size = 100 } = {}) {
   return apiRequest(`/api/me/liked-playlists?${params.toString()}`)
 }
 
+export async function isPlaylistLiked(playlistId) {
+  const pageSize = 100
+  let page = 0
+
+  while (true) {
+    const likedPlaylists = await getLikedPlaylists({ page, size: pageSize })
+    if (!Array.isArray(likedPlaylists)) {
+      return false
+    }
+
+    if (likedPlaylists.some((playlist) => playlist.playlistId === Number(playlistId))) {
+      return true
+    }
+
+    if (likedPlaylists.length < pageSize) {
+      return false
+    }
+
+    page += 1
+  }
+}
+
 export function createPlaylistComment(playlistId, content) {
   return apiRequest(`/api/playlists/${playlistId}/comments`, {
     method: 'POST',

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -2,7 +2,7 @@ import { Button } from '../common/Button.jsx'
 import { useAuth } from '../../hooks/useAuth.js'
 
 export function AppShell({ children }) {
-  const { logout, user } = useAuth()
+  const { isAuthenticated, logout, user } = useAuth()
 
   return (
     <div className="app-shell">
@@ -27,12 +27,18 @@ export function AppShell({ children }) {
       <div className="main-column">
         <header className="top-bar">
           <div>
-            <span className="eyebrow">Signed in</span>
-            <strong>{user.nickname}</strong>
+            <span className="eyebrow">{isAuthenticated ? 'Signed in' : 'Guest'}</span>
+            <strong>{user?.nickname ?? '둘러보기 모드'}</strong>
           </div>
-          <Button className="button-secondary" onClick={logout}>
-            로그아웃
-          </Button>
+          {isAuthenticated ? (
+            <Button className="button-secondary" onClick={logout}>
+              로그아웃
+            </Button>
+          ) : (
+            <a className="button button-secondary top-login-link" href="#login">
+              로그인
+            </a>
+          )}
         </header>
         {children}
       </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { AppShell } from '../components/layout/AppShell.jsx'
 import { Button } from '../components/common/Button.jsx'
 import { EmptyState } from '../components/common/EmptyState.jsx'
 import { getPublicPlaylists } from '../api/playlistApi.js'
+import { useAuth } from '../hooks/useAuth.js'
 
 const dashboardItems = [
   {
@@ -44,6 +45,7 @@ const filterValueParsers = {
 }
 
 export function HomePage({ onSelectPlaylist }) {
+  const { isAuthenticated } = useAuth()
   const [keywordInput, setKeywordInput] = useState('')
   const [filters, setFilters] = useState({
     keyword: '',
@@ -128,7 +130,7 @@ export function HomePage({ onSelectPlaylist }) {
             <p className="eyebrow">Dashboard</p>
             <h1>플레이리스트 작업대</h1>
           </div>
-          <span className="status-pill">세션 활성</span>
+          <span className="status-pill">{isAuthenticated ? '세션 활성' : '둘러보기'}</span>
         </section>
 
         <section className="dashboard-grid" aria-label="주요 작업">

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -2,11 +2,11 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   createPlaylistComment,
   deletePlaylistComment,
-  getLikedPlaylists,
   getPlaylist,
   getPlaylistComments,
   getPlaylistTracks,
   getSimilarPlaylists,
+  isPlaylistLiked,
   likePlaylist,
   unlikePlaylist,
 } from '../api/playlistApi.js'
@@ -41,12 +41,12 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setHasLiked(false)
 
       try {
-        const [playlist, tracks, comments, similarPlaylists, likedPlaylists] = await Promise.all([
+        const [playlist, tracks, comments, similarPlaylists, liked] = await Promise.all([
           getPlaylist(playlistId),
           getPlaylistTracks(playlistId).catch(() => []),
           getPlaylistComments(playlistId, { size: 20 }).catch(() => []),
           getSimilarPlaylists(playlistId).catch(() => []),
-          currentUser ? getLikedPlaylists({ size: 100 }).catch(() => []) : Promise.resolve([]),
+          currentUser ? isPlaylistLiked(playlistId).catch(() => false) : Promise.resolve(false),
         ])
 
         if (!isActive) {
@@ -59,11 +59,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
           comments: Array.isArray(comments) ? comments : [],
           similarPlaylists: Array.isArray(similarPlaylists) ? similarPlaylists : [],
         })
-        setHasLiked(
-          Array.isArray(likedPlaylists)
-            ? likedPlaylists.some((likedPlaylist) => likedPlaylist.playlistId === Number(playlistId))
-            : false,
-        )
+        setHasLiked(liked)
       } catch (error) {
         if (isActive) {
           setErrorMessage(error.message ?? '플레이리스트 상세를 불러오지 못했습니다.')

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   createPlaylistComment,
   deletePlaylistComment,
+  getLikedPlaylists,
   getPlaylist,
   getPlaylistComments,
   getPlaylistTracks,
@@ -40,11 +41,12 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setHasLiked(false)
 
       try {
-        const [playlist, tracks, comments, similarPlaylists] = await Promise.all([
+        const [playlist, tracks, comments, similarPlaylists, likedPlaylists] = await Promise.all([
           getPlaylist(playlistId),
           getPlaylistTracks(playlistId).catch(() => []),
           getPlaylistComments(playlistId, { size: 20 }).catch(() => []),
           getSimilarPlaylists(playlistId).catch(() => []),
+          currentUser ? getLikedPlaylists({ size: 100 }).catch(() => []) : Promise.resolve([]),
         ])
 
         if (!isActive) {
@@ -57,6 +59,11 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
           comments: Array.isArray(comments) ? comments : [],
           similarPlaylists: Array.isArray(similarPlaylists) ? similarPlaylists : [],
         })
+        setHasLiked(
+          Array.isArray(likedPlaylists)
+            ? likedPlaylists.some((likedPlaylist) => likedPlaylist.playlistId === Number(playlistId))
+            : false,
+        )
       } catch (error) {
         if (isActive) {
           setErrorMessage(error.message ?? '플레이리스트 상세를 불러오지 못했습니다.')
@@ -73,7 +80,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     return () => {
       isActive = false
     }
-  }, [playlistId])
+  }, [currentUser, playlistId])
 
   const { comments, playlist, similarPlaylists, tracks } = detail
   const isOwner = currentUser?.userId === playlist?.userId

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -29,6 +29,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [deletingCommentId, setDeletingCommentId] = useState(null)
   const [hasLiked, setHasLiked] = useState(false)
   const [isLikeSubmitting, setIsLikeSubmitting] = useState(false)
+  const currentUserId = currentUser?.userId
 
   useEffect(() => {
     let isActive = true
@@ -46,7 +47,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
           getPlaylistTracks(playlistId).catch(() => []),
           getPlaylistComments(playlistId, { size: 20 }).catch(() => []),
           getSimilarPlaylists(playlistId).catch(() => []),
-          currentUser ? isPlaylistLiked(playlistId).catch(() => false) : Promise.resolve(false),
+          currentUserId ? isPlaylistLiked(playlistId).catch(() => false) : Promise.resolve(false),
         ])
 
         if (!isActive) {
@@ -76,10 +77,10 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     return () => {
       isActive = false
     }
-  }, [currentUser, playlistId])
+  }, [currentUserId, playlistId])
 
   const { comments, playlist, similarPlaylists, tracks } = detail
-  const isOwner = currentUser?.userId === playlist?.userId
+  const isOwner = currentUserId === playlist?.userId
   const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) || 'TS', [playlist?.title])
   const trimmedComment = commentContent.trim()
 
@@ -263,7 +264,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
               <div className="panel detail-panel">
                 <div className="panel-header">
                   <h2>댓글</h2>
-                  <span>{comments.length} comments</span>
+                  <span>{formatCount(playlist.commentCount)} comments</span>
                 </div>
                 <form className="comment-form" onSubmit={handleCommentSubmit}>
                   <label htmlFor="playlist-comment">댓글 작성</label>

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from 'react'
-import { getPlaylist, getPlaylistComments, getPlaylistTracks, getSimilarPlaylists } from '../api/playlistApi.js'
+import {
+  createPlaylistComment,
+  deletePlaylistComment,
+  getPlaylist,
+  getPlaylistComments,
+  getPlaylistTracks,
+  getSimilarPlaylists,
+  likePlaylist,
+  unlikePlaylist,
+} from '../api/playlistApi.js'
 import { Button } from '../components/common/Button.jsx'
 import { EmptyState } from '../components/common/EmptyState.jsx'
 import { AppShell } from '../components/layout/AppShell.jsx'
@@ -13,6 +22,12 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   })
   const [isLoading, setIsLoading] = useState(true)
   const [errorMessage, setErrorMessage] = useState('')
+  const [commentContent, setCommentContent] = useState('')
+  const [actionMessage, setActionMessage] = useState('')
+  const [isCommentSubmitting, setIsCommentSubmitting] = useState(false)
+  const [deletingCommentId, setDeletingCommentId] = useState(null)
+  const [hasLiked, setHasLiked] = useState(false)
+  const [isLikeSubmitting, setIsLikeSubmitting] = useState(false)
 
   useEffect(() => {
     let isActive = true
@@ -20,6 +35,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     async function fetchDetail() {
       setIsLoading(true)
       setErrorMessage('')
+      setCommentContent('')
+      setActionMessage('')
+      setHasLiked(false)
 
       try {
         const [playlist, tracks, comments, similarPlaylists] = await Promise.all([
@@ -60,6 +78,107 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const { comments, playlist, similarPlaylists, tracks } = detail
   const isOwner = currentUser?.userId === playlist?.userId
   const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) || 'TS', [playlist?.title])
+  const trimmedComment = commentContent.trim()
+
+  async function handleLikeToggle() {
+    if (!playlist) {
+      return
+    }
+
+    if (!currentUser) {
+      setActionMessage('좋아요를 남기려면 먼저 로그인해 주세요.')
+      return
+    }
+
+    setIsLikeSubmitting(true)
+    setActionMessage('')
+
+    try {
+      const response = hasLiked ? await unlikePlaylist(playlist.playlistId) : await likePlaylist(playlist.playlistId)
+      setHasLiked(Boolean(response.liked))
+      updatePlaylist({
+        likeCount: response.likeCount,
+      })
+    } catch (error) {
+      setActionMessage(error.message ?? '좋아요 상태를 변경하지 못했습니다.')
+    } finally {
+      setIsLikeSubmitting(false)
+    }
+  }
+
+  async function handleCommentSubmit(event) {
+    event.preventDefault()
+
+    if (!playlist || !trimmedComment) {
+      return
+    }
+
+    if (!currentUser) {
+      setActionMessage('댓글을 작성하려면 먼저 로그인해 주세요.')
+      return
+    }
+
+    setIsCommentSubmitting(true)
+    setActionMessage('')
+
+    try {
+      const createdComment = await createPlaylistComment(playlist.playlistId, trimmedComment)
+      setDetail((currentDetail) => ({
+        ...currentDetail,
+        playlist: currentDetail.playlist
+          ? {
+              ...currentDetail.playlist,
+              commentCount: Number(currentDetail.playlist.commentCount ?? 0) + 1,
+            }
+          : currentDetail.playlist,
+        comments: [...currentDetail.comments, createdComment],
+      }))
+      setCommentContent('')
+    } catch (error) {
+      setActionMessage(error.message ?? '댓글을 등록하지 못했습니다.')
+    } finally {
+      setIsCommentSubmitting(false)
+    }
+  }
+
+  async function handleCommentDelete(commentId) {
+    if (!window.confirm('댓글을 삭제할까요?')) {
+      return
+    }
+
+    setDeletingCommentId(commentId)
+    setActionMessage('')
+
+    try {
+      await deletePlaylistComment(commentId)
+      setDetail((currentDetail) => ({
+        ...currentDetail,
+        playlist: currentDetail.playlist
+          ? {
+              ...currentDetail.playlist,
+              commentCount: Math.max(Number(currentDetail.playlist.commentCount ?? 0) - 1, 0),
+            }
+          : currentDetail.playlist,
+        comments: currentDetail.comments.filter((comment) => comment.commentId !== commentId),
+      }))
+    } catch (error) {
+      setActionMessage(error.message ?? '댓글을 삭제하지 못했습니다.')
+    } finally {
+      setDeletingCommentId(null)
+    }
+  }
+
+  function updatePlaylist(updates) {
+    setDetail((currentDetail) => ({
+      ...currentDetail,
+      playlist: currentDetail.playlist
+        ? {
+            ...currentDetail.playlist,
+            ...updates,
+          }
+        : currentDetail.playlist,
+    }))
+  }
 
   return (
     <AppShell>
@@ -110,8 +229,16 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
                   <Stat label="댓글" value={playlist.commentCount} />
                   <Stat label="복사" value={playlist.copyCount} />
                 </div>
+
+                <div className="detail-actions">
+                  <Button className={hasLiked ? 'button-primary' : 'button-secondary'} disabled={isLikeSubmitting} onClick={handleLikeToggle}>
+                    {isLikeSubmitting ? '처리 중' : hasLiked ? '좋아요 취소' : '좋아요'}
+                  </Button>
+                </div>
               </div>
             </section>
+
+            {actionMessage ? <p className="panel-error detail-action-message">{actionMessage}</p> : null}
 
             <section className="detail-grid">
               <div className="panel detail-panel">
@@ -135,10 +262,33 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
                   <h2>댓글</h2>
                   <span>{comments.length} comments</span>
                 </div>
+                <form className="comment-form" onSubmit={handleCommentSubmit}>
+                  <label htmlFor="playlist-comment">댓글 작성</label>
+                  <textarea
+                    id="playlist-comment"
+                    maxLength={1000}
+                    onChange={(event) => setCommentContent(event.target.value)}
+                    placeholder={currentUser ? '플레이리스트에 대한 감상을 남겨보세요.' : '로그인 후 댓글을 작성할 수 있습니다.'}
+                    rows={4}
+                    value={commentContent}
+                  />
+                  <div className="comment-form-actions">
+                    <span>{trimmedComment.length}/1000</span>
+                    <Button disabled={isCommentSubmitting || !trimmedComment} type="submit">
+                      {isCommentSubmitting ? '등록 중' : '댓글 등록'}
+                    </Button>
+                  </div>
+                </form>
                 {comments.length > 0 ? (
                   <div className="comment-list">
                     {comments.map((comment) => (
-                      <CommentItem comment={comment} key={comment.commentId} />
+                      <CommentItem
+                        comment={comment}
+                        currentUser={currentUser}
+                        deletingCommentId={deletingCommentId}
+                        key={comment.commentId}
+                        onDelete={handleCommentDelete}
+                      />
                     ))}
                   </div>
                 ) : (
@@ -209,12 +359,22 @@ function TrackRow({ track }) {
   )
 }
 
-function CommentItem({ comment }) {
+function CommentItem({ comment, currentUser, deletingCommentId, onDelete }) {
+  const isCommentOwner = currentUser?.userId === comment.userId
+  const isDeleting = deletingCommentId === comment.commentId
+
   return (
     <article className="comment-item">
       <div>
-        <strong>{comment.userNickname}</strong>
-        <span>{formatDate(comment.createdAt)}</span>
+        <div>
+          <strong>{comment.userNickname}</strong>
+          <span>{formatDate(comment.createdAt)}</span>
+        </div>
+        {isCommentOwner ? (
+          <Button className="button-ghost comment-delete-button" disabled={isDeleting} onClick={() => onDelete(comment.commentId)}>
+            {isDeleting ? '삭제 중' : '삭제'}
+          </Button>
+        ) : null}
       </div>
       <p>{comment.content}</p>
     </article>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -16,6 +16,7 @@
 .button:focus-visible,
 input:focus-visible,
 select:focus-visible,
+textarea:focus-visible,
 a:focus-visible {
   outline: 2px solid var(--color-cyan);
   outline-offset: 3px;
@@ -28,6 +29,14 @@ a:focus-visible {
 
 .button-secondary {
   border-color: var(--color-border);
+}
+
+.button-ghost {
+  min-height: 36px;
+  border-color: var(--color-border);
+  padding: 0 12px;
+  color: var(--color-muted);
+  background: transparent;
 }
 
 .boot-screen,
@@ -523,6 +532,16 @@ a:focus-visible {
   font-size: 20px;
 }
 
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.detail-action-message {
+  margin-top: -4px;
+}
+
 .detail-grid {
   display: grid;
   grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
@@ -594,6 +613,44 @@ a:focus-visible {
   text-align: right;
 }
 
+.comment-form {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.comment-form label {
+  color: var(--color-subtle);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.comment-form textarea {
+  width: 100%;
+  min-height: 112px;
+  resize: vertical;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--color-text);
+  background: var(--color-background);
+  font: inherit;
+  line-height: 1.5;
+}
+
+.comment-form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.comment-form-actions span {
+  color: var(--color-subtle);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
 .comment-item {
   border: 1px solid var(--color-border);
   border-radius: 8px;
@@ -601,12 +658,18 @@ a:focus-visible {
   background: var(--color-surface-raised);
 }
 
-.comment-item div {
+.comment-item > div {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   color: var(--color-subtle);
   font-size: 13px;
+}
+
+.comment-item > div > div {
+  display: grid;
+  gap: 4px;
 }
 
 .comment-item strong {
@@ -617,6 +680,10 @@ a:focus-visible {
   margin: 10px 0 0;
   color: var(--color-muted);
   line-height: 1.6;
+}
+
+.comment-delete-button {
+  flex: 0 0 auto;
 }
 
 .similar-list {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1,4 +1,7 @@
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 44px;
   border: 1px solid transparent;
   border-radius: 8px;
@@ -6,6 +9,7 @@
   color: var(--color-text);
   background: var(--color-surface-raised);
   cursor: pointer;
+  text-decoration: none;
 }
 
 .button:disabled {


### PR DESCRIPTION
## 요약
- 플레이리스트 상세 화면에 좋아요/좋아요 취소 버튼을 연결했습니다.
- 댓글 작성과 본인 댓글 삭제를 상세 화면에서 처리합니다.
- 비로그인 사용자가 공개 목록/상세를 볼 수 있도록 라우팅과 상단 로그인 진입점을 보정했습니다.
- 로그인 사용자는 `/api/me/liked-playlists` 기준으로 좋아요 초기 상태를 맞춥니다.

## 검증
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #31