### PR TITLE
[Frontend] 플레이리스트 생성 빌더 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './contexts/AuthProvider.jsx'
 import { useAuth } from './hooks/useAuth.js'
 import { HomePage } from './pages/HomePage.jsx'
 import { LoginPage } from './pages/LoginPage.jsx'
+import { PlaylistBuilderPage } from './pages/PlaylistBuilderPage.jsx'
 import { PlaylistDetailPage } from './pages/PlaylistDetailPage.jsx'
 
 function App() {
@@ -40,6 +41,17 @@ function AppContent() {
     return <LoginPage />
   }
 
+  if (hashState.isBuilderRoute) {
+    return (
+      <PlaylistBuilderPage
+        currentUser={user}
+        onCreated={(playlistId) => {
+          window.location.hash = `playlist/${playlistId}`
+        }}
+      />
+    )
+  }
+
   if (hashState.selectedPlaylistId) {
     return (
       <PlaylistDetailPage
@@ -67,6 +79,7 @@ function AppContent() {
 function getHashState() {
   const match = window.location.hash.match(/^#playlist\/(\d+)$/)
   return {
+    isBuilderRoute: window.location.hash === '#playlist-builder',
     isLoginRoute: window.location.hash === '#login',
     selectedPlaylistId: match ? Number(match[1]) : null,
   }

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -16,8 +16,36 @@ export function getPlaylist(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}`)
 }
 
+export function createPlaylist({ coverImageUrl = '', description = '', publicYn = true, title }) {
+  return apiRequest('/api/playlists', {
+    method: 'POST',
+    body: JSON.stringify({
+      coverImageUrl,
+      description,
+      publicYn,
+      title,
+    }),
+  })
+}
+
 export function getPlaylistTracks(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}/tracks`)
+}
+
+export function addPlaylistTrack(playlistId, track) {
+  return apiRequest(`/api/playlists/${playlistId}/tracks`, {
+    method: 'POST',
+    body: JSON.stringify({
+      albumImageUrl: track.albumImageUrl,
+      albumName: track.albumName,
+      artistName: track.artistName,
+      durationMs: track.durationMs,
+      previewUrl: track.previewUrl,
+      spotifyTrackId: track.spotifyTrackId,
+      spotifyUrl: track.spotifyUrl,
+      title: track.title,
+    }),
+  })
 }
 
 export function getPlaylistComments(playlistId, { page = 0, size = 20 } = {}) {
@@ -91,4 +119,14 @@ export function unlikePlaylist(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}/likes`, {
     method: 'DELETE',
   })
+}
+
+export function searchSpotifyTracks({ page = 0, query, size = 10 }) {
+  const params = new URLSearchParams({
+    q: query,
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/spotify/search/tracks?${params.toString()}`, { skipAuth: true })
 }

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -19,6 +19,7 @@ export function AppShell({ children }) {
 
         <nav className="sidebar-nav">
           <a href="#public-playlists">공개 플레이리스트</a>
+          <a href="#playlist-builder">새 플레이리스트</a>
           <a href="#my-playlists">내 플레이리스트</a>
           <a href="#track-search">곡 검색</a>
         </nav>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -13,8 +13,8 @@ const dashboardItems = [
     tone: 'green',
   },
   {
-    id: 'my-playlists',
-    label: '내 플레이리스트',
+    id: 'playlist-builder',
+    label: '새 플레이리스트',
     metric: 'Create',
     tone: 'cyan',
   },
@@ -237,6 +237,11 @@ export function HomePage({ onSelectPlaylist }) {
               title="아직 만든 플레이리스트가 없습니다"
               description="나만의 첫 플레이리스트를 준비할 차례입니다."
             />
+            <div className="panel-actions">
+              <a className="button button-primary" href="#playlist-builder">
+                새 플레이리스트 만들기
+              </a>
+            </div>
           </div>
         </section>
       </main>

--- a/frontend/src/pages/PlaylistBuilderPage.jsx
+++ b/frontend/src/pages/PlaylistBuilderPage.jsx
@@ -1,0 +1,300 @@
+import { useState } from 'react'
+import { addPlaylistTrack, createPlaylist, searchSpotifyTracks } from '../api/playlistApi.js'
+import { Button } from '../components/common/Button.jsx'
+import { EmptyState } from '../components/common/EmptyState.jsx'
+import { AppShell } from '../components/layout/AppShell.jsx'
+
+export function PlaylistBuilderPage({ currentUser, onCreated }) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [isPublic, setIsPublic] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState([])
+  const [selectedTracks, setSelectedTracks] = useState([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [searchMessage, setSearchMessage] = useState('')
+  const [saveMessage, setSaveMessage] = useState('')
+
+  async function handleSearchSubmit(event) {
+    event.preventDefault()
+    const query = searchQuery.trim()
+    if (!query) {
+      setSearchMessage('검색어를 입력해 주세요.')
+      return
+    }
+
+    setIsSearching(true)
+    setSearchMessage('')
+
+    try {
+      const response = await searchSpotifyTracks({ query })
+      const tracks = Array.isArray(response.tracks) ? response.tracks : []
+      setSearchResults(tracks)
+      if (tracks.length === 0) {
+        setSearchMessage('검색 결과가 없습니다.')
+      }
+    } catch (error) {
+      setSearchMessage(error.message ?? '곡 검색에 실패했습니다.')
+    } finally {
+      setIsSearching(false)
+    }
+  }
+
+  async function handleSave() {
+    const trimmedTitle = title.trim()
+    if (!currentUser) {
+      setSaveMessage('플레이리스트를 만들려면 먼저 로그인해 주세요.')
+      return
+    }
+    if (!trimmedTitle) {
+      setSaveMessage('제목을 입력해 주세요.')
+      return
+    }
+
+    setIsSaving(true)
+    setSaveMessage('')
+
+    let createdPlaylist
+    try {
+      createdPlaylist = await createPlaylist({
+        coverImageUrl: selectedTracks[0]?.albumImageUrl ?? '',
+        description: description.trim(),
+        publicYn: isPublic,
+        title: trimmedTitle,
+      })
+
+      for (const track of selectedTracks) {
+        await addPlaylistTrack(createdPlaylist.playlistId, track)
+      }
+
+      onCreated(createdPlaylist.playlistId)
+    } catch (error) {
+      const baseMessage = error.message ?? '플레이리스트를 저장하지 못했습니다.'
+      if (createdPlaylist?.playlistId) {
+        setSaveMessage(`${baseMessage} 생성된 플레이리스트는 상세 화면에서 확인할 수 있습니다.`)
+      } else {
+        setSaveMessage(baseMessage)
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  function addTrack(track) {
+    setSaveMessage('')
+    setSelectedTracks((currentTracks) => {
+      if (currentTracks.some((selectedTrack) => selectedTrack.spotifyTrackId === track.spotifyTrackId)) {
+        return currentTracks
+      }
+      return [...currentTracks, track]
+    })
+  }
+
+  function removeTrack(spotifyTrackId) {
+    setSelectedTracks((currentTracks) => currentTracks.filter((track) => track.spotifyTrackId !== spotifyTrackId))
+  }
+
+  function moveTrack(spotifyTrackId, direction) {
+    setSelectedTracks((currentTracks) => {
+      const index = currentTracks.findIndex((track) => track.spotifyTrackId === spotifyTrackId)
+      const nextIndex = index + direction
+      if (index < 0 || nextIndex < 0 || nextIndex >= currentTracks.length) {
+        return currentTracks
+      }
+
+      const nextTracks = [...currentTracks]
+      const [track] = nextTracks.splice(index, 1)
+      nextTracks.splice(nextIndex, 0, track)
+      return nextTracks
+    })
+  }
+
+  return (
+    <AppShell>
+      <main className="workspace builder-workspace">
+        <section className="workspace-header">
+          <div>
+            <p className="eyebrow">Playlist Builder</p>
+            <h1>새 플레이리스트 만들기</h1>
+          </div>
+          <a className="button button-secondary" href="#public-playlists">
+            목록으로
+          </a>
+        </section>
+
+        {!currentUser ? (
+          <section className="panel builder-auth-panel">
+            <EmptyState title="로그인이 필요합니다" description="플레이리스트를 만들려면 로그인 후 다시 시도해 주세요." />
+            <a className="button button-primary" href="#login">
+              로그인
+            </a>
+          </section>
+        ) : (
+          <section className="builder-grid">
+            <div className="panel builder-panel">
+              <div className="panel-header">
+                <h2>기본 정보</h2>
+                <span>{isPublic ? 'public' : 'private'}</span>
+              </div>
+
+              <div className="builder-form">
+                <label>
+                  <span>제목</span>
+                  <input
+                    maxLength={100}
+                    onChange={(event) => setTitle(event.target.value)}
+                    placeholder="예: 새벽 집중 믹스"
+                    value={title}
+                  />
+                </label>
+
+                <label>
+                  <span>설명</span>
+                  <textarea
+                    onChange={(event) => setDescription(event.target.value)}
+                    placeholder="어떤 순간에 어울리는 플레이리스트인지 적어보세요."
+                    rows={6}
+                    value={description}
+                  />
+                </label>
+
+                <label className="builder-toggle">
+                  <input checked={isPublic} onChange={(event) => setIsPublic(event.target.checked)} type="checkbox" />
+                  <span>공개 플레이리스트로 게시</span>
+                </label>
+
+                {saveMessage ? <p className="panel-error">{saveMessage}</p> : null}
+
+                <Button className="button-primary" disabled={isSaving} onClick={handleSave}>
+                  {isSaving ? '저장 중' : `플레이리스트 저장 · ${selectedTracks.length}곡`}
+                </Button>
+              </div>
+            </div>
+
+            <div className="panel builder-panel">
+              <div className="panel-header">
+                <h2>Spotify 곡 검색</h2>
+                <span>{searchResults.length} results</span>
+              </div>
+
+              <form className="builder-search" onSubmit={handleSearchSubmit}>
+                <input
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="곡명 또는 아티스트 검색"
+                  type="search"
+                  value={searchQuery}
+                />
+                <Button className="button-secondary" disabled={isSearching} type="submit">
+                  {isSearching ? '검색 중' : '검색'}
+                </Button>
+              </form>
+
+              {searchMessage ? <p className="panel-error">{searchMessage}</p> : null}
+
+              {searchResults.length > 0 ? (
+                <div className="builder-track-list" aria-live="polite">
+                  {searchResults.map((track) => (
+                    <TrackCandidate
+                      isSelected={selectedTracks.some((selectedTrack) => selectedTrack.spotifyTrackId === track.spotifyTrackId)}
+                      key={track.spotifyTrackId}
+                      onAdd={addTrack}
+                      track={track}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <EmptyState title="검색 결과가 없습니다" description="Spotify 카탈로그에서 곡을 찾아 추가할 수 있습니다." />
+              )}
+            </div>
+
+            <div className="panel builder-panel builder-selected-panel">
+              <div className="panel-header">
+                <h2>담은 곡</h2>
+                <span>{selectedTracks.length} tracks</span>
+              </div>
+
+              {selectedTracks.length > 0 ? (
+                <div className="builder-selected-list">
+                  {selectedTracks.map((track, index) => (
+                    <SelectedTrack
+                      index={index}
+                      isFirst={index === 0}
+                      isLast={index === selectedTracks.length - 1}
+                      key={track.spotifyTrackId}
+                      onMove={moveTrack}
+                      onRemove={removeTrack}
+                      track={track}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <EmptyState title="아직 담은 곡이 없습니다" description="검색 결과에서 곡을 추가하면 저장 순서대로 표시됩니다." />
+              )}
+            </div>
+          </section>
+        )}
+      </main>
+    </AppShell>
+  )
+}
+
+function TrackCandidate({ isSelected, onAdd, track }) {
+  return (
+    <article className="builder-track-card">
+      <TrackArtwork track={track} />
+      <TrackText track={track} />
+      <Button className="button-secondary" disabled={isSelected} onClick={() => onAdd(track)}>
+        {isSelected ? '추가됨' : '추가'}
+      </Button>
+    </article>
+  )
+}
+
+function SelectedTrack({ index, isFirst, isLast, onMove, onRemove, track }) {
+  return (
+    <article className="builder-selected-track">
+      <span className="builder-track-index">{index + 1}</span>
+      <TrackArtwork track={track} />
+      <TrackText track={track} />
+      <div className="builder-track-actions">
+        <Button className="button-ghost" disabled={isFirst} onClick={() => onMove(track.spotifyTrackId, -1)}>
+          위
+        </Button>
+        <Button className="button-ghost" disabled={isLast} onClick={() => onMove(track.spotifyTrackId, 1)}>
+          아래
+        </Button>
+        <Button className="button-ghost" onClick={() => onRemove(track.spotifyTrackId)}>
+          제거
+        </Button>
+      </div>
+    </article>
+  )
+}
+
+function TrackArtwork({ track }) {
+  return (
+    <div className="builder-track-cover" aria-hidden="true">
+      {track.albumImageUrl ? <img src={track.albumImageUrl} alt="" /> : <span>{track.title?.slice(0, 1) ?? 'T'}</span>}
+    </div>
+  )
+}
+
+function TrackText({ track }) {
+  return (
+    <div className="builder-track-text">
+      <strong>{track.title}</strong>
+      <span>{track.artistName}</span>
+      <small>
+        {track.albumName || '앨범 정보 없음'} · {formatDuration(track.durationMs)}
+      </small>
+    </div>
+  )
+}
+
+function formatDuration(durationMs) {
+  const totalSeconds = Math.floor(Number(durationMs ?? 0) / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -424,6 +424,172 @@ a:focus-visible {
   margin-top: 16px;
 }
 
+.panel-actions {
+  display: flex;
+  margin-top: 16px;
+}
+
+.builder-workspace {
+  display: grid;
+  gap: 16px;
+}
+
+.builder-auth-panel {
+  display: grid;
+  min-height: 360px;
+  justify-items: center;
+}
+
+.builder-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.builder-panel {
+  min-height: 0;
+}
+
+.builder-selected-panel {
+  grid-column: 1 / -1;
+}
+
+.builder-form,
+.builder-search {
+  display: grid;
+  gap: 12px;
+}
+
+.builder-form label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.builder-form input,
+.builder-form textarea,
+.builder-search input {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  background: var(--color-background);
+  font: inherit;
+}
+
+.builder-form input,
+.builder-search input {
+  min-height: 44px;
+  padding: 0 12px;
+}
+
+.builder-form textarea {
+  min-height: 132px;
+  resize: vertical;
+  padding: 12px;
+  line-height: 1.5;
+}
+
+.builder-form .builder-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.builder-form .builder-toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.builder-search {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.builder-track-list,
+.builder-selected-list {
+  display: grid;
+  gap: 10px;
+}
+
+.builder-track-card,
+.builder-selected-track {
+  display: grid;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-surface-raised);
+}
+
+.builder-track-card {
+  grid-template-columns: 58px minmax(0, 1fr) auto;
+}
+
+.builder-selected-track {
+  grid-template-columns: 34px 58px minmax(0, 1fr) auto;
+}
+
+.builder-track-index {
+  color: var(--color-subtle);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-align: center;
+}
+
+.builder-track-cover {
+  display: grid;
+  overflow: hidden;
+  width: 58px;
+  height: 58px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background: var(--color-cyan);
+  font-weight: 800;
+}
+
+.builder-track-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.builder-track-text {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.builder-track-text strong,
+.builder-track-text span,
+.builder-track-text small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.builder-track-text span,
+.builder-track-text small {
+  color: var(--color-subtle);
+}
+
+.builder-track-text small {
+  font-size: 12px;
+}
+
+.builder-track-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 .detail-workspace {
   display: grid;
   gap: 16px;
@@ -754,8 +920,12 @@ a:focus-visible {
   .app-shell,
   .dashboard-grid,
   .content-grid,
+  .builder-grid,
   .detail-grid,
   .detail-hero,
+  .builder-search,
+  .builder-track-card,
+  .builder-selected-track,
   .playlist-toolbar,
   .playlist-card,
   .similar-list,
@@ -797,7 +967,7 @@ a:focus-visible {
   }
 
   .sidebar-nav {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .sidebar-nav a {


### PR DESCRIPTION
## 요약
- 새 플레이리스트 생성 화면과 해시 라우팅을 추가했습니다.
- 제목/설명/공개 여부 입력, Spotify 곡 검색, 곡 추가/제거/순서 변경 UI를 구현했습니다.
- 저장 시 플레이리스트를 생성한 뒤 선택 곡을 순서대로 추가하고 상세 화면으로 이동합니다.
- 비로그인 사용자는 생성 화면에서 로그인 진입을 안내합니다.

## 검증
- npm run lint
- npm run build
- git diff --check
- gstack /review clean

Closes #33