### PR TITLE
[Frontend] 마이페이지 활동 요약 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './contexts/AuthProvider.jsx'
 import { useAuth } from './hooks/useAuth.js'
 import { HomePage } from './pages/HomePage.jsx'
 import { LoginPage } from './pages/LoginPage.jsx'
+import { MyPage } from './pages/MyPage.jsx'
 import { PlaylistBuilderPage } from './pages/PlaylistBuilderPage.jsx'
 import { PlaylistDetailPage } from './pages/PlaylistDetailPage.jsx'
 
@@ -52,6 +53,17 @@ function AppContent() {
     )
   }
 
+  if (hashState.isMyPageRoute) {
+    return (
+      <MyPage
+        currentUser={user}
+        onSelectPlaylist={(playlistId) => {
+          window.location.hash = `playlist/${playlistId}`
+        }}
+      />
+    )
+  }
+
   if (hashState.selectedPlaylistId) {
     return (
       <PlaylistDetailPage
@@ -81,6 +93,7 @@ function getHashState() {
   return {
     isBuilderRoute: window.location.hash === '#playlist-builder',
     isLoginRoute: window.location.hash === '#login',
+    isMyPageRoute: window.location.hash === '#my-playlists',
     selectedPlaylistId: match ? Number(match[1]) : null,
   }
 }

--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -74,6 +74,24 @@ export function getLikedPlaylists({ page = 0, size = 100 } = {}) {
   return apiRequest(`/api/me/liked-playlists?${params.toString()}`)
 }
 
+export function getMyPlaylists({ page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/me/playlists?${params.toString()}`)
+}
+
+export function getMyComments({ page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  })
+
+  return apiRequest(`/api/me/comments?${params.toString()}`)
+}
+
 export async function isPlaylistLiked(playlistId) {
   const pageSize = 100
   let page = 0

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react'
+import { getLikedPlaylists, getMyComments, getMyPlaylists } from '../api/playlistApi.js'
+import { EmptyState } from '../components/common/EmptyState.jsx'
+import { AppShell } from '../components/layout/AppShell.jsx'
+
+export function MyPage({ currentUser, onSelectPlaylist }) {
+  const [myPlaylists, setMyPlaylists] = useState([])
+  const [myComments, setMyComments] = useState([])
+  const [likedPlaylists, setLikedPlaylists] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const currentUserId = currentUser?.userId
+
+  useEffect(() => {
+    let isActive = true
+
+    async function fetchMyActivity() {
+      if (!currentUserId) {
+        return
+      }
+
+      setIsLoading(true)
+      setErrorMessage('')
+
+      try {
+        const [playlists, comments, liked] = await Promise.all([
+          getMyPlaylists({ size: 20 }),
+          getMyComments({ size: 20 }),
+          getLikedPlaylists({ size: 20 }),
+        ])
+
+        if (!isActive) {
+          return
+        }
+
+        setMyPlaylists(Array.isArray(playlists) ? playlists : [])
+        setMyComments(Array.isArray(comments) ? comments : [])
+        setLikedPlaylists(Array.isArray(liked) ? liked : [])
+      } catch (error) {
+        if (isActive) {
+          setErrorMessage(error.message ?? '내 활동을 불러오지 못했습니다.')
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchMyActivity()
+
+    return () => {
+      isActive = false
+    }
+  }, [currentUserId])
+
+  return (
+    <AppShell>
+      <main className="workspace my-workspace">
+        <section className="workspace-header">
+          <div>
+            <p className="eyebrow">My Page</p>
+            <h1>내 활동</h1>
+          </div>
+          <a className="button button-primary" href="#playlist-builder">
+            새 플레이리스트
+          </a>
+        </section>
+
+        {!currentUser ? (
+          <section className="panel my-auth-panel">
+            <EmptyState title="로그인이 필요합니다" description="내 플레이리스트와 활동을 보려면 로그인해 주세요." />
+            <a className="button button-primary" href="#login">
+              로그인
+            </a>
+          </section>
+        ) : (
+          <>
+            <section className="my-summary-grid" aria-label="내 활동 요약">
+              <SummaryCard label="최근 플레이리스트" value={myPlaylists.length} />
+              <SummaryCard label="최근 댓글" value={myComments.length} />
+              <SummaryCard label="최근 좋아요" value={likedPlaylists.length} />
+            </section>
+
+            {errorMessage ? <p className="panel-error">{errorMessage}</p> : null}
+
+            <section className="my-grid">
+              <ActivityPanel
+                emptyDescription="새 플레이리스트 빌더에서 첫 목록을 만들어 보세요."
+                emptyTitle={isLoading ? '내 플레이리스트를 불러오는 중입니다' : '아직 만든 플레이리스트가 없습니다'}
+                eyebrow="created"
+                title="내 플레이리스트"
+              >
+                {myPlaylists.length > 0 ? (
+                  <div className="my-list">
+                    {myPlaylists.map((playlist) => (
+                      <PlaylistActivityItem key={playlist.playlistId} onSelectPlaylist={onSelectPlaylist} playlist={playlist} />
+                    ))}
+                  </div>
+                ) : null}
+              </ActivityPanel>
+
+              <ActivityPanel
+                emptyDescription="상세 화면에서 플레이리스트에 의견을 남기면 여기에 모입니다."
+                emptyTitle={isLoading ? '댓글을 불러오는 중입니다' : '아직 남긴 댓글이 없습니다'}
+                eyebrow="comments"
+                title="내 댓글"
+              >
+                {myComments.length > 0 ? (
+                  <div className="my-list">
+                    {myComments.map((comment) => (
+                      <CommentActivityItem comment={comment} key={comment.commentId} onSelectPlaylist={onSelectPlaylist} />
+                    ))}
+                  </div>
+                ) : null}
+              </ActivityPanel>
+
+              <ActivityPanel
+                emptyDescription="마음에 드는 공개 플레이리스트에 좋아요를 남겨보세요."
+                emptyTitle={isLoading ? '좋아요한 목록을 불러오는 중입니다' : '좋아요한 플레이리스트가 없습니다'}
+                eyebrow="liked"
+                title="좋아요한 플레이리스트"
+              >
+                {likedPlaylists.length > 0 ? (
+                  <div className="my-list">
+                    {likedPlaylists.map((playlist) => (
+                      <PlaylistActivityItem key={playlist.playlistId} onSelectPlaylist={onSelectPlaylist} playlist={playlist} />
+                    ))}
+                  </div>
+                ) : null}
+              </ActivityPanel>
+            </section>
+          </>
+        )}
+      </main>
+    </AppShell>
+  )
+}
+
+function SummaryCard({ label, value }) {
+  return (
+    <div className="my-summary-card">
+      <strong>{formatCount(value)}</strong>
+      <span>{label}</span>
+    </div>
+  )
+}
+
+function ActivityPanel({ children, emptyDescription, emptyTitle, eyebrow, title }) {
+  const hasChildren = Boolean(children)
+
+  return (
+    <div className="panel my-panel">
+      <div className="panel-header">
+        <h2>{title}</h2>
+        <span>{eyebrow}</span>
+      </div>
+      {hasChildren ? children : <EmptyState title={emptyTitle} description={emptyDescription} />}
+    </div>
+  )
+}
+
+function PlaylistActivityItem({ onSelectPlaylist, playlist }) {
+  return (
+    <button className="my-activity-item" onClick={() => onSelectPlaylist(playlist.playlistId)} type="button">
+      <div className="my-activity-cover" aria-hidden="true">
+        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title?.slice(0, 2) ?? 'TS'}</span>}
+      </div>
+      <div className="my-activity-main">
+        <strong>{playlist.title}</strong>
+        <span>{playlist.description || '설명이 없는 플레이리스트입니다.'}</span>
+        <small>
+          좋아요 {formatCount(playlist.likeCount)} · 댓글 {formatCount(playlist.commentCount)} · 조회 {formatCount(playlist.viewCount)}
+        </small>
+      </div>
+    </button>
+  )
+}
+
+function CommentActivityItem({ comment, onSelectPlaylist }) {
+  return (
+    <button className="my-activity-item" onClick={() => onSelectPlaylist(comment.playlistId)} type="button">
+      <div className="my-comment-mark" aria-hidden="true">
+        C
+      </div>
+      <div className="my-activity-main">
+        <strong>{comment.playlistTitle}</strong>
+        <span>{comment.content}</span>
+        <small>작성 {formatDate(comment.createdAt)}</small>
+      </div>
+    </button>
+  )
+}
+
+function formatCount(value) {
+  return Number(value ?? 0).toLocaleString('ko-KR')
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '-'
+  }
+
+  return new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -24,9 +24,9 @@ export function MyPage({ currentUser, onSelectPlaylist }) {
 
       try {
         const [playlists, comments, liked] = await Promise.all([
-          getMyPlaylists({ size: 20 }),
-          getMyComments({ size: 20 }),
-          getLikedPlaylists({ size: 20 }),
+          getMyPlaylists({ size: 20 }).catch(() => []),
+          getMyComments({ size: 20 }).catch(() => []),
+          getLikedPlaylists({ size: 20 }).catch(() => []),
         ])
 
         if (!isActive) {
@@ -164,7 +164,7 @@ function PlaylistActivityItem({ onSelectPlaylist, playlist }) {
   return (
     <button className="my-activity-item" onClick={() => onSelectPlaylist(playlist.playlistId)} type="button">
       <div className="my-activity-cover" aria-hidden="true">
-        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title?.slice(0, 2) ?? 'TS'}</span>}
+        {playlist.coverImageUrl ? <img src={playlist.coverImageUrl} alt="" /> : <span>{playlist.title?.slice(0, 2) || 'TS'}</span>}
       </div>
       <div className="my-activity-main">
         <strong>{playlist.title}</strong>
@@ -196,13 +196,15 @@ function formatCount(value) {
   return Number(value ?? 0).toLocaleString('ko-KR')
 }
 
+const dateFormatter = new Intl.DateTimeFormat('ko-KR', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+})
+
 function formatDate(value) {
   if (!value) {
     return '-'
   }
 
-  return new Intl.DateTimeFormat('ko-KR', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(new Date(value))
+  return dateFormatter.format(new Date(value))
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -590,6 +590,123 @@ a:focus-visible {
   gap: 6px;
 }
 
+.my-workspace {
+  display: grid;
+  gap: 16px;
+}
+
+.my-auth-panel {
+  display: grid;
+  min-height: 360px;
+  justify-items: center;
+}
+
+.my-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.my-summary-card {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 18px;
+  background: var(--color-surface);
+}
+
+.my-summary-card strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--color-text);
+  font-size: 28px;
+}
+
+.my-summary-card span {
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.my-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+.my-panel {
+  min-height: 360px;
+}
+
+.my-list {
+  display: grid;
+  gap: 10px;
+}
+
+.my-activity-item {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px;
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+  text-align: left;
+  cursor: pointer;
+}
+
+.my-activity-item:hover {
+  border-color: rgba(56, 189, 248, 0.62);
+}
+
+.my-activity-cover,
+.my-comment-mark {
+  display: grid;
+  overflow: hidden;
+  width: 58px;
+  height: 58px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background: var(--color-cyan);
+  font-weight: 800;
+}
+
+.my-comment-mark {
+  background: var(--color-green);
+}
+
+.my-activity-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.my-activity-main {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.my-activity-main strong,
+.my-activity-main span,
+.my-activity-main small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.my-activity-main span,
+.my-activity-main small {
+  color: var(--color-subtle);
+}
+
+.my-activity-main small {
+  font-size: 12px;
+}
+
 .detail-workspace {
   display: grid;
   gap: 16px;
@@ -921,11 +1038,14 @@ a:focus-visible {
   .dashboard-grid,
   .content-grid,
   .builder-grid,
+  .my-grid,
+  .my-summary-grid,
   .detail-grid,
   .detail-hero,
   .builder-search,
   .builder-track-card,
   .builder-selected-track,
+  .my-activity-item,
   .playlist-toolbar,
   .playlist-card,
   .similar-list,


### PR DESCRIPTION
## 요약
- `#my-playlists` 라우트에 마이페이지 화면을 추가했습니다.
- 내가 만든 플레이리스트, 내가 남긴 댓글, 좋아요한 플레이리스트를 각각 조회합니다.
- 각 활동 항목에서 관련 플레이리스트 상세로 이동할 수 있습니다.
- 비로그인 사용자는 로그인 안내를 봅니다.

## 검증
- npm run lint
- npm run build
- git diff --check
- gstack /review clean

Closes #35