### PR TITLE
[Frontend] 플레이리스트 상세 수정·삭제 UI 구현

### DIFF
--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -28,6 +28,24 @@ export function createPlaylist({ coverImageUrl = '', description = '', publicYn 
   })
 }
 
+export function updatePlaylist(playlistId, { coverImageUrl = '', description = '', publicYn = true, title }) {
+  return apiRequest(`/api/playlists/${playlistId}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      coverImageUrl,
+      description,
+      publicYn,
+      title,
+    }),
+  })
+}
+
+export function deletePlaylist(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}`, {
+    method: 'DELETE',
+  })
+}
+
 export function getPlaylistTracks(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}/tracks`)
 }

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import {
   createPlaylistComment,
+  deletePlaylist,
   deletePlaylistComment,
   getPlaylist,
   getPlaylistComments,
@@ -9,6 +10,7 @@ import {
   isPlaylistLiked,
   likePlaylist,
   unlikePlaylist,
+  updatePlaylist as requestPlaylistUpdate,
 } from '../api/playlistApi.js'
 import { Button } from '../components/common/Button.jsx'
 import { EmptyState } from '../components/common/EmptyState.jsx'
@@ -29,6 +31,12 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [deletingCommentId, setDeletingCommentId] = useState(null)
   const [hasLiked, setHasLiked] = useState(false)
   const [isLikeSubmitting, setIsLikeSubmitting] = useState(false)
+  const [isEditingPlaylist, setIsEditingPlaylist] = useState(false)
+  const [editTitle, setEditTitle] = useState('')
+  const [editDescription, setEditDescription] = useState('')
+  const [editPublicYn, setEditPublicYn] = useState(true)
+  const [isPlaylistSaving, setIsPlaylistSaving] = useState(false)
+  const [isPlaylistDeleting, setIsPlaylistDeleting] = useState(false)
   const currentUserId = currentUser?.userId
 
   useEffect(() => {
@@ -40,6 +48,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setCommentContent('')
       setActionMessage('')
       setHasLiked(false)
+      setIsEditingPlaylist(false)
 
       try {
         const [playlist, tracks, comments, similarPlaylists, liked] = await Promise.all([
@@ -60,6 +69,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
           comments: Array.isArray(comments) ? comments : [],
           similarPlaylists: Array.isArray(similarPlaylists) ? similarPlaylists : [],
         })
+        setEditTitle(playlist.title ?? '')
+        setEditDescription(playlist.description ?? '')
+        setEditPublicYn(Boolean(playlist.publicYn))
         setHasLiked(liked)
       } catch (error) {
         if (isActive) {
@@ -83,6 +95,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const isOwner = currentUserId === playlist?.userId
   const heroInitials = useMemo(() => playlist?.title?.slice(0, 2) || 'TS', [playlist?.title])
   const trimmedComment = commentContent.trim()
+  const trimmedEditTitle = editTitle.trim()
 
   async function handleLikeToggle() {
     if (!playlist) {
@@ -107,6 +120,66 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setActionMessage(error.message ?? '좋아요 상태를 변경하지 못했습니다.')
     } finally {
       setIsLikeSubmitting(false)
+    }
+  }
+
+  function openPlaylistEditForm() {
+    if (!playlist) {
+      return
+    }
+
+    setEditTitle(playlist.title ?? '')
+    setEditDescription(playlist.description ?? '')
+    setEditPublicYn(Boolean(playlist.publicYn))
+    setActionMessage('')
+    setIsEditingPlaylist(true)
+  }
+
+  async function handlePlaylistUpdate(event) {
+    event.preventDefault()
+
+    if (!playlist || !isOwner || !trimmedEditTitle) {
+      return
+    }
+
+    setIsPlaylistSaving(true)
+    setActionMessage('')
+
+    try {
+      const updatedPlaylist = await requestPlaylistUpdate(playlist.playlistId, {
+        coverImageUrl: playlist.coverImageUrl ?? '',
+        description: editDescription.trim(),
+        publicYn: editPublicYn,
+        title: trimmedEditTitle,
+      })
+      updatePlaylist(updatedPlaylist ?? {
+        description: editDescription.trim(),
+        publicYn: editPublicYn,
+        title: trimmedEditTitle,
+      })
+      setIsEditingPlaylist(false)
+      setActionMessage('플레이리스트 정보를 수정했습니다.')
+    } catch (error) {
+      setActionMessage(error.message ?? '플레이리스트 정보를 수정하지 못했습니다.')
+    } finally {
+      setIsPlaylistSaving(false)
+    }
+  }
+
+  async function handlePlaylistDelete() {
+    if (!playlist || !isOwner || !window.confirm('플레이리스트를 삭제할까요? 삭제 후에는 목록에서 사라집니다.')) {
+      return
+    }
+
+    setIsPlaylistDeleting(true)
+    setActionMessage('')
+
+    try {
+      await deletePlaylist(playlist.playlistId)
+      onBack()
+    } catch (error) {
+      setActionMessage(error.message ?? '플레이리스트를 삭제하지 못했습니다.')
+      setIsPlaylistDeleting(false)
     }
   }
 
@@ -238,11 +311,52 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
                   <Button className={hasLiked ? 'button-primary' : 'button-secondary'} disabled={isLikeSubmitting} onClick={handleLikeToggle}>
                     {isLikeSubmitting ? '처리 중' : hasLiked ? '좋아요 취소' : '좋아요'}
                   </Button>
+                  {isOwner ? (
+                    <>
+                      <Button className="button-secondary" disabled={isPlaylistDeleting} onClick={openPlaylistEditForm}>
+                        수정
+                      </Button>
+                      <Button className="button-danger" disabled={isPlaylistDeleting} onClick={handlePlaylistDelete}>
+                        {isPlaylistDeleting ? '삭제 중' : '삭제'}
+                      </Button>
+                    </>
+                  ) : null}
                 </div>
               </div>
             </section>
 
             {actionMessage ? <p className="panel-error detail-action-message">{actionMessage}</p> : null}
+
+            {isOwner && isEditingPlaylist ? (
+              <section className="panel detail-edit-panel">
+                <div className="panel-header">
+                  <h2>플레이리스트 정보 수정</h2>
+                  <span>{trimmedEditTitle.length}/100</span>
+                </div>
+                <form className="detail-edit-form" onSubmit={handlePlaylistUpdate}>
+                  <label>
+                    제목
+                    <input maxLength={100} onChange={(event) => setEditTitle(event.target.value)} required value={editTitle} />
+                  </label>
+                  <label>
+                    설명
+                    <textarea onChange={(event) => setEditDescription(event.target.value)} rows={4} value={editDescription} />
+                  </label>
+                  <label className="detail-toggle">
+                    <input checked={editPublicYn} onChange={(event) => setEditPublicYn(event.target.checked)} type="checkbox" />
+                    공개 플레이리스트
+                  </label>
+                  <div className="detail-edit-actions">
+                    <Button disabled={isPlaylistSaving || !trimmedEditTitle} type="submit">
+                      {isPlaylistSaving ? '저장 중' : '저장'}
+                    </Button>
+                    <Button className="button-secondary" disabled={isPlaylistSaving} onClick={() => setIsEditingPlaylist(false)}>
+                      취소
+                    </Button>
+                  </div>
+                </form>
+              </section>
+            ) : null}
 
             <section className="detail-grid">
               <div className="panel detail-panel">

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -27,6 +27,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [errorMessage, setErrorMessage] = useState('')
   const [commentContent, setCommentContent] = useState('')
   const [actionMessage, setActionMessage] = useState('')
+  const [actionMessageType, setActionMessageType] = useState('error')
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false)
   const [deletingCommentId, setDeletingCommentId] = useState(null)
   const [hasLiked, setHasLiked] = useState(false)
@@ -46,7 +47,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setIsLoading(true)
       setErrorMessage('')
       setCommentContent('')
-      setActionMessage('')
+      clearActionMessage()
       setHasLiked(false)
       setIsEditingPlaylist(false)
 
@@ -97,18 +98,28 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const trimmedComment = commentContent.trim()
   const trimmedEditTitle = editTitle.trim()
 
+  function clearActionMessage() {
+    setActionMessage('')
+    setActionMessageType('error')
+  }
+
+  function showActionMessage(message, type = 'error') {
+    setActionMessage(message)
+    setActionMessageType(type)
+  }
+
   async function handleLikeToggle() {
     if (!playlist) {
       return
     }
 
     if (!currentUser) {
-      setActionMessage('좋아요를 남기려면 먼저 로그인해 주세요.')
+      showActionMessage('좋아요를 남기려면 먼저 로그인해 주세요.')
       return
     }
 
     setIsLikeSubmitting(true)
-    setActionMessage('')
+    clearActionMessage()
 
     try {
       const response = hasLiked ? await unlikePlaylist(playlist.playlistId) : await likePlaylist(playlist.playlistId)
@@ -117,7 +128,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
         likeCount: response.likeCount,
       })
     } catch (error) {
-      setActionMessage(error.message ?? '좋아요 상태를 변경하지 못했습니다.')
+      showActionMessage(error.message ?? '좋아요 상태를 변경하지 못했습니다.')
     } finally {
       setIsLikeSubmitting(false)
     }
@@ -131,7 +142,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     setEditTitle(playlist.title ?? '')
     setEditDescription(playlist.description ?? '')
     setEditPublicYn(Boolean(playlist.publicYn))
-    setActionMessage('')
+    clearActionMessage()
     setIsEditingPlaylist(true)
   }
 
@@ -143,7 +154,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     }
 
     setIsPlaylistSaving(true)
-    setActionMessage('')
+    clearActionMessage()
 
     try {
       const updatedPlaylist = await requestPlaylistUpdate(playlist.playlistId, {
@@ -158,9 +169,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
         title: trimmedEditTitle,
       })
       setIsEditingPlaylist(false)
-      setActionMessage('플레이리스트 정보를 수정했습니다.')
+      showActionMessage('플레이리스트 정보를 수정했습니다.', 'success')
     } catch (error) {
-      setActionMessage(error.message ?? '플레이리스트 정보를 수정하지 못했습니다.')
+      showActionMessage(error.message ?? '플레이리스트 정보를 수정하지 못했습니다.')
     } finally {
       setIsPlaylistSaving(false)
     }
@@ -172,13 +183,14 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     }
 
     setIsPlaylistDeleting(true)
-    setActionMessage('')
+    clearActionMessage()
 
     try {
       await deletePlaylist(playlist.playlistId)
+      setIsPlaylistDeleting(false)
       onBack()
     } catch (error) {
-      setActionMessage(error.message ?? '플레이리스트를 삭제하지 못했습니다.')
+      showActionMessage(error.message ?? '플레이리스트를 삭제하지 못했습니다.')
       setIsPlaylistDeleting(false)
     }
   }
@@ -191,12 +203,12 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     }
 
     if (!currentUser) {
-      setActionMessage('댓글을 작성하려면 먼저 로그인해 주세요.')
+      showActionMessage('댓글을 작성하려면 먼저 로그인해 주세요.')
       return
     }
 
     setIsCommentSubmitting(true)
-    setActionMessage('')
+    clearActionMessage()
 
     try {
       const createdComment = await createPlaylistComment(playlist.playlistId, trimmedComment)
@@ -212,7 +224,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       }))
       setCommentContent('')
     } catch (error) {
-      setActionMessage(error.message ?? '댓글을 등록하지 못했습니다.')
+      showActionMessage(error.message ?? '댓글을 등록하지 못했습니다.')
     } finally {
       setIsCommentSubmitting(false)
     }
@@ -224,7 +236,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     }
 
     setDeletingCommentId(commentId)
-    setActionMessage('')
+    clearActionMessage()
 
     try {
       await deletePlaylistComment(commentId)
@@ -239,7 +251,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
         comments: currentDetail.comments.filter((comment) => comment.commentId !== commentId),
       }))
     } catch (error) {
-      setActionMessage(error.message ?? '댓글을 삭제하지 못했습니다.')
+      showActionMessage(error.message ?? '댓글을 삭제하지 못했습니다.')
     } finally {
       setDeletingCommentId(null)
     }
@@ -325,7 +337,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
               </div>
             </section>
 
-            {actionMessage ? <p className="panel-error detail-action-message">{actionMessage}</p> : null}
+            {actionMessage ? (
+              <p className={`${actionMessageType === 'success' ? 'panel-success' : 'panel-error'} detail-action-message`}>{actionMessage}</p>
+            ) : null}
 
             {isOwner && isEditingPlaylist ? (
               <section className="panel detail-edit-panel">

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -35,6 +35,12 @@ a:focus-visible {
   border-color: var(--color-border);
 }
 
+.button-danger {
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.34);
+}
+
 .button-ghost {
   min-height: 36px;
   border-color: var(--color-border);
@@ -827,6 +833,62 @@ a:focus-visible {
 
 .detail-action-message {
   margin-top: -4px;
+}
+
+.detail-edit-panel {
+  min-height: 0;
+}
+
+.detail-edit-form {
+  display: grid;
+  gap: 12px;
+}
+
+.detail-edit-form label {
+  display: grid;
+  gap: 7px;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.detail-edit-form input,
+.detail-edit-form textarea {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  background: var(--color-background);
+  font: inherit;
+}
+
+.detail-edit-form input {
+  min-height: 44px;
+  padding: 0 12px;
+}
+
+.detail-edit-form textarea {
+  min-height: 112px;
+  resize: vertical;
+  padding: 12px;
+  line-height: 1.5;
+}
+
+.detail-edit-form .detail-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.detail-edit-form .detail-toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.detail-edit-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .detail-grid {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -349,6 +349,12 @@ a:focus-visible {
   font-size: 14px;
 }
 
+.panel-success {
+  margin: 0 0 14px;
+  color: var(--color-green);
+  font-size: 14px;
+}
+
 .playlist-list {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## 변경 사항
- 플레이리스트 상세 화면에 작성자 전용 수정/삭제 액션을 추가했습니다.
- 제목, 설명, 공개 여부 수정 폼과 PUT /api/playlists/{playlistId} 연결을 추가했습니다.
- 삭제 확인 후 DELETE /api/playlists/{playlistId}를 호출하고 공개 목록으로 돌아가도록 했습니다.

## 검증
- npm run lint
- npm run build
- git diff --check
- gstack /review: clean

Closes #37