### PR TITLE
[Frontend] 플레이리스트 상세 복사 UI 구현

### DIFF
--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -46,6 +46,12 @@ export function deletePlaylist(playlistId) {
   })
 }
 
+export function copyPlaylist(playlistId) {
+  return apiRequest(`/api/playlists/${playlistId}/copy`, {
+    method: 'POST',
+  })
+}
+
 export function getPlaylistTracks(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}/tracks`)
 }

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   addPlaylistTrack,
+  copyPlaylist,
   createPlaylistComment,
   deletePlaylist,
   deletePlaylistComment,
@@ -41,6 +42,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [editDescription, setEditDescription] = useState('')
   const [editPublicYn, setEditPublicYn] = useState(true)
   const [isPlaylistSaving, setIsPlaylistSaving] = useState(false)
+  const [isPlaylistCopying, setIsPlaylistCopying] = useState(false)
   const [isPlaylistDeleting, setIsPlaylistDeleting] = useState(false)
   const [trackSearchQuery, setTrackSearchQuery] = useState('')
   const [trackSearchResults, setTrackSearchResults] = useState([])
@@ -50,7 +52,20 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [addingTrackId, setAddingTrackId] = useState(null)
   const [deletingTrackId, setDeletingTrackId] = useState(null)
   const [reorderingTrackId, setReorderingTrackId] = useState(null)
+  const isMountedRef = useRef(false)
+  const activePlaylistIdRef = useRef(playlistId)
+  const copyRedirectTimeoutRef = useRef(null)
   const currentUserId = currentUser?.userId
+  activePlaylistIdRef.current = playlistId
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    return () => {
+      isMountedRef.current = false
+      window.clearTimeout(copyRedirectTimeoutRef.current)
+    }
+  }, [])
 
   useEffect(() => {
     let isActive = true
@@ -65,6 +80,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setTrackSearchResults([])
       setHasLiked(false)
       setIsEditingPlaylist(false)
+      setIsPlaylistCopying(false)
 
       try {
         const [playlist, tracks, comments, similarPlaylists, liked] = await Promise.all([
@@ -104,6 +120,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
 
     return () => {
       isActive = false
+      window.clearTimeout(copyRedirectTimeoutRef.current)
     }
   }, [currentUserId, playlistId])
 
@@ -219,6 +236,41 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
     } catch (error) {
       showActionMessage(error.message ?? '플레이리스트를 삭제하지 못했습니다.')
       setIsPlaylistDeleting(false)
+    }
+  }
+
+  async function handlePlaylistCopy() {
+    if (!playlist || isOwner) {
+      return
+    }
+
+    if (!currentUser) {
+      showActionMessage('플레이리스트를 복사하려면 먼저 로그인해 주세요.')
+      return
+    }
+
+    setIsPlaylistCopying(true)
+    clearActionMessage()
+
+    const sourcePlaylistId = playlist.playlistId
+
+    try {
+      const copiedPlaylist = await copyPlaylist(sourcePlaylistId)
+      if (!isMountedRef.current || activePlaylistIdRef.current !== sourcePlaylistId) {
+        return
+      }
+
+      updatePlaylist({
+        copyCount: Number(playlist.copyCount ?? 0) + 1,
+      })
+      showActionMessage('플레이리스트를 복사했습니다. 복사본으로 이동합니다.', 'success')
+      window.clearTimeout(copyRedirectTimeoutRef.current)
+      copyRedirectTimeoutRef.current = window.setTimeout(() => {
+        onSelectPlaylist(copiedPlaylist.playlistId)
+      }, 500)
+    } catch (error) {
+      showActionMessage(error.message ?? '플레이리스트를 복사하지 못했습니다.')
+      setIsPlaylistCopying(false)
     }
   }
 
@@ -468,7 +520,11 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
                         {isPlaylistDeleting ? '삭제 중' : '삭제'}
                       </Button>
                     </>
-                  ) : null}
+                  ) : (
+                    <Button className="button-secondary" disabled={isPlaylistCopying} onClick={handlePlaylistCopy}>
+                      {isPlaylistCopying ? '복사 중' : '복사'}
+                    </Button>
+                  )}
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## 요약

- 플레이리스트 상세 화면에 비소유자용 복사 버튼을 추가했습니다.
- 비로그인 복사 시도는 로그인 안내 메시지로 처리합니다.
- 복사 요청 중 중복 클릭을 막고, 성공 시 복사본 플레이리스트 상세로 이동합니다.

## 검증

- npm run lint
- npm run build
- git diff --check origin/main
- gstack /review clean

Closes #41