### PR TITLE
[Frontend] 홈 Spotify 곡 검색 패널 구현

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { AppShell } from '../components/layout/AppShell.jsx'
 import { Button } from '../components/common/Button.jsx'
 import { EmptyState } from '../components/common/EmptyState.jsx'
-import { getPublicPlaylists } from '../api/playlistApi.js'
+import { getPublicPlaylists, searchSpotifyTracks } from '../api/playlistApi.js'
 import { useAuth } from '../hooks/useAuth.js'
 
 const dashboardItems = [
@@ -58,6 +58,21 @@ export function HomePage({ onSelectPlaylist }) {
   const [isLoading, setIsLoading] = useState(false)
   const [hasMore, setHasMore] = useState(true)
   const [errorMessage, setErrorMessage] = useState('')
+  const [trackSearchInput, setTrackSearchInput] = useState('')
+  const [trackResults, setTrackResults] = useState([])
+  const [isTrackSearching, setIsTrackSearching] = useState(false)
+  const [trackSearchMessage, setTrackSearchMessage] = useState('')
+  const trackSearchRequestRef = useRef(0)
+  const isMountedRef = useRef(false)
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    return () => {
+      isMountedRef.current = false
+      trackSearchRequestRef.current += 1
+    }
+  }, [])
 
   useEffect(() => {
     let isActive = true
@@ -120,6 +135,44 @@ export function HomePage({ onSelectPlaylist }) {
       ...current,
       [name]: filterValueParsers[name]?.(value) ?? value,
     }))
+  }
+
+  async function handleTrackSearchSubmit(event) {
+    event.preventDefault()
+    const query = trackSearchInput.trim()
+
+    if (!query) {
+      setTrackSearchMessage('검색어를 입력해 주세요.')
+      return
+    }
+
+    setIsTrackSearching(true)
+    setTrackSearchMessage('')
+    const requestId = trackSearchRequestRef.current + 1
+    trackSearchRequestRef.current = requestId
+
+    try {
+      const response = await searchSpotifyTracks({ query, size: 8 })
+      if (!isMountedRef.current || trackSearchRequestRef.current !== requestId) {
+        return
+      }
+
+      const tracks = Array.isArray(response.tracks) ? response.tracks : []
+      setTrackResults(tracks)
+      if (tracks.length === 0) {
+        setTrackSearchMessage('검색 결과가 없습니다.')
+      }
+    } catch (error) {
+      if (!isMountedRef.current || trackSearchRequestRef.current !== requestId) {
+        return
+      }
+
+      setTrackSearchMessage(error.message ?? '곡 검색에 실패했습니다.')
+    } finally {
+      if (isMountedRef.current && trackSearchRequestRef.current === requestId) {
+        setIsTrackSearching(false)
+      }
+    }
   }
 
   return (
@@ -243,6 +296,37 @@ export function HomePage({ onSelectPlaylist }) {
               </a>
             </div>
           </div>
+
+          <div id="track-search" className="panel">
+            <div className="panel-header">
+              <h2>Spotify 곡 검색</h2>
+              <span>{trackResults.length} results</span>
+            </div>
+
+            <form className="home-track-search" onSubmit={handleTrackSearchSubmit}>
+              <input
+                onChange={(event) => setTrackSearchInput(event.target.value)}
+                placeholder="곡명 또는 아티스트 검색"
+                type="search"
+                value={trackSearchInput}
+              />
+              <Button className="button-secondary" disabled={isTrackSearching} type="submit">
+                {isTrackSearching ? '검색 중' : '검색'}
+              </Button>
+            </form>
+
+            {trackSearchMessage ? <p className="panel-error">{trackSearchMessage}</p> : null}
+
+            {trackResults.length > 0 ? (
+              <div className="home-track-list" aria-live="polite">
+                {trackResults.map((track) => (
+                  <TrackSearchItem key={track.spotifyTrackId} track={track} />
+                ))}
+              </div>
+            ) : (
+              <EmptyState title="검색 결과가 없습니다" description="Spotify 카탈로그에서 곡과 아티스트를 찾아볼 수 있습니다." />
+            )}
+          </div>
         </section>
       </main>
     </AppShell>
@@ -281,6 +365,35 @@ function PlaylistCard({ onSelectPlaylist, playlist }) {
   )
 }
 
+function TrackSearchItem({ track }) {
+  return (
+    <article className="home-track-item">
+      <div className="home-track-cover" aria-hidden="true">
+        {track.albumImageUrl ? <img src={track.albumImageUrl} alt="" /> : <span>{track.title?.slice(0, 1) ?? 'T'}</span>}
+      </div>
+      <div className="home-track-main">
+        <strong>{track.title}</strong>
+        <span>{track.artistName}</span>
+        <small>
+          {track.albumName || '앨범 정보 없음'} · {formatDuration(track.durationMs)}
+        </small>
+      </div>
+      {track.spotifyUrl ? (
+        <a className="button button-ghost" href={track.spotifyUrl} rel="noreferrer" target="_blank">
+          Spotify
+        </a>
+      ) : null}
+    </article>
+  )
+}
+
 function formatCount(value) {
   return Number(value ?? 0).toLocaleString('ko-KR')
+}
+
+function formatDuration(durationMs) {
+  const totalSeconds = Math.floor(Number(durationMs ?? 0) / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -157,11 +157,8 @@ export function HomePage({ onSelectPlaylist }) {
         return
       }
 
-      const tracks = Array.isArray(response.tracks) ? response.tracks : []
+      const tracks = Array.isArray(response.items) ? response.items : []
       setTrackResults(tracks)
-      if (tracks.length === 0) {
-        setTrackSearchMessage('검색 결과가 없습니다.')
-      }
     } catch (error) {
       if (!isMountedRef.current || trackSearchRequestRef.current !== requestId) {
         return
@@ -300,7 +297,7 @@ export function HomePage({ onSelectPlaylist }) {
           <div id="track-search" className="panel">
             <div className="panel-header">
               <h2>Spotify 곡 검색</h2>
-              <span>{trackResults.length} results</span>
+              <span>{trackResults.length}개의 결과</span>
             </div>
 
             <form className="home-track-search" onSubmit={handleTrackSearchSubmit}>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -441,6 +441,82 @@ a:focus-visible {
   margin-top: 16px;
 }
 
+.home-track-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.home-track-search input {
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0 12px;
+  color: var(--color-text);
+  background: var(--color-background);
+  font: inherit;
+}
+
+.home-track-list {
+  display: grid;
+  gap: 10px;
+}
+
+.home-track-item {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-surface-raised);
+}
+
+.home-track-cover {
+  display: grid;
+  overflow: hidden;
+  width: 58px;
+  height: 58px;
+  place-items: center;
+  border-radius: 8px;
+  color: #07110b;
+  background: var(--color-rose);
+  font-weight: 800;
+}
+
+.home-track-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.home-track-main {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.home-track-main strong,
+.home-track-main span,
+.home-track-main small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-track-main span,
+.home-track-main small {
+  color: var(--color-subtle);
+}
+
+.home-track-main small {
+  font-size: 12px;
+}
+
 .builder-workspace {
   display: grid;
   gap: 16px;
@@ -1155,6 +1231,8 @@ a:focus-visible {
   .detail-grid,
   .detail-hero,
   .builder-search,
+  .home-track-search,
+  .home-track-item,
   .track-search-form,
   .track-candidate,
   .builder-track-card,


### PR DESCRIPTION
## 요약

- 홈 화면에 Spotify 곡 검색 패널을 추가했습니다.
- 기존 대시보드의 Spotify 곡 검색 카드가 실제 track-search 섹션으로 이동합니다.
- 검색 결과에 앨범 아트, 곡명, 아티스트, 앨범, 길이, Spotify 외부 링크를 표시합니다.
- 검색 응답이 늦게 도착해도 언마운트되었거나 더 최신 검색이 있는 경우 상태를 덮어쓰지 않도록 처리했습니다.

## 검증

- npm run lint
- npm run build
- git diff --check origin/main
- gstack /review clean

Closes #43