### PR TITLE
[Frontend] 곡 검색 응답 계약 및 라벨 정리

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -157,7 +157,7 @@ export function HomePage({ onSelectPlaylist }) {
         return
       }
 
-      const tracks = Array.isArray(response.items) ? response.items : []
+      const tracks = Array.isArray(response.tracks) ? response.tracks : []
       setTrackResults(tracks)
     } catch (error) {
       if (!isMountedRef.current || trackSearchRequestRef.current !== requestId) {

--- a/frontend/src/pages/PlaylistBuilderPage.jsx
+++ b/frontend/src/pages/PlaylistBuilderPage.jsx
@@ -31,9 +31,6 @@ export function PlaylistBuilderPage({ currentUser, onCreated }) {
       const response = await searchSpotifyTracks({ query })
       const tracks = Array.isArray(response.tracks) ? response.tracks : []
       setSearchResults(tracks)
-      if (tracks.length === 0) {
-        setSearchMessage('검색 결과가 없습니다.')
-      }
     } catch (error) {
       setSearchMessage(error.message ?? '곡 검색에 실패했습니다.')
     } finally {
@@ -175,7 +172,7 @@ export function PlaylistBuilderPage({ currentUser, onCreated }) {
             <div className="panel builder-panel">
               <div className="panel-header">
                 <h2>Spotify 곡 검색</h2>
-                <span>{searchResults.length} results</span>
+                <span>{searchResults.length}개의 결과</span>
               </div>
 
               <form className="builder-search" onSubmit={handleSearchSubmit}>
@@ -211,7 +208,7 @@ export function PlaylistBuilderPage({ currentUser, onCreated }) {
             <div className="panel builder-panel builder-selected-panel">
               <div className="panel-header">
                 <h2>담은 곡</h2>
-                <span>{selectedTracks.length} tracks</span>
+                <span>{selectedTracks.length}곡</span>
               </div>
 
               {selectedTracks.length > 0 ? (

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -568,7 +568,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
               <div className="panel detail-panel">
                 <div className="panel-header">
                   <h2>수록곡</h2>
-                  <span>{tracks.length} tracks</span>
+                  <span>{tracks.length}곡</span>
                 </div>
                 {isOwner ? (
                   <div className="track-manager">
@@ -629,7 +629,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
               <div className="panel detail-panel">
                 <div className="panel-header">
                   <h2>댓글</h2>
-                  <span>{formatCount(playlist.commentCount)} comments</span>
+                  <span>{formatCount(playlist.commentCount)}개</span>
                 </div>
                 <form className="comment-form" onSubmit={handleCommentSubmit}>
                   <label htmlFor="playlist-comment">댓글 작성</label>
@@ -669,7 +669,7 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
             <section className="panel detail-panel">
               <div className="panel-header">
                 <h2>유사 플레이리스트</h2>
-                <span>{similarPlaylists.length} similar</span>
+                <span>{similarPlaylists.length}개</span>
               </div>
               {similarPlaylists.length > 0 ? (
                 <div className="similar-list">


### PR DESCRIPTION
## 요약

- 홈 Spotify 곡 검색 결과 파싱을 백엔드 DTO 계약인 `response.tracks` 기준으로 복구했습니다.
- 빌더 검색의 빈 결과 메시지 중복 표시를 제거했습니다.
- 빌더/상세 화면의 곡, 댓글, 유사 플레이리스트 개수 라벨을 한국어 표기로 맞췄습니다.

Closes #45

## 검증

- `npm run lint`
- `npm run build`
- `git diff --check`
- `./gradlew test`