### PR TITLE
[Search] 공개 플레이리스트 설명 검색 추가

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -28,6 +28,7 @@ const dashboardItems = [
 
 const searchTypeOptions = [
   { value: 'title', label: '제목' },
+  { value: 'description', label: '설명' },
   { value: 'author', label: '작성자' },
 ]
 

--- a/src/main/java/com/tunesharehub/service/PlaylistService.java
+++ b/src/main/java/com/tunesharehub/service/PlaylistService.java
@@ -20,6 +20,7 @@ public class PlaylistService {
     private static final String PUBLIC_YN_TRUE = "Y";
     private static final String PUBLIC_YN_FALSE = "N";
     private static final String SEARCH_TYPE_TITLE = "title";
+    private static final String SEARCH_TYPE_DESCRIPTION = "description";
     private static final String SEARCH_TYPE_AUTHOR = "author";
     private static final String SORT_LATEST = "latest";
     private static final String SORT_VIEW = "view";
@@ -282,6 +283,9 @@ public class PlaylistService {
         String normalizedSearchType = searchType.trim().toLowerCase(Locale.ROOT);
         if (SEARCH_TYPE_AUTHOR.equals(normalizedSearchType)) {
             return SEARCH_TYPE_AUTHOR;
+        }
+        if (SEARCH_TYPE_DESCRIPTION.equals(normalizedSearchType)) {
+            return SEARCH_TYPE_DESCRIPTION;
         }
         if (SEARCH_TYPE_TITLE.equals(normalizedSearchType)) {
             return SEARCH_TYPE_TITLE;

--- a/src/main/resources/mappers/PlaylistMapper.xml
+++ b/src/main/resources/mappers/PlaylistMapper.xml
@@ -107,6 +107,9 @@
                 <when test="searchType == 'author'">
                     AND U.NICKNAME LIKE '%' || #{keyword} || '%'
                 </when>
+                <when test="searchType == 'description'">
+                    AND DBMS_LOB.INSTR(P.DESCRIPTION, #{keyword}) > 0
+                </when>
                 <otherwise>
                     AND P.TITLE LIKE '%' || #{keyword} || '%'
                 </otherwise>

--- a/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
+++ b/src/test/java/com/tunesharehub/service/PlaylistServiceTest.java
@@ -55,6 +55,16 @@ class PlaylistServiceTest {
     }
 
     @Test
+    void getPublicPlaylistsAcceptsDescriptionSearch() {
+        when(playlistMapper.findPublicPlaylists("새벽", "description", "latest", 0, 20))
+                .thenReturn(List.of());
+
+        playlistService.getPublicPlaylists(" 새벽 ", " Description ", " latest ", 0, 20);
+
+        verify(playlistMapper).findPublicPlaylists("새벽", "description", "latest", 0, 20);
+    }
+
+    @Test
     void getLikedPlaylistsReturnsUserLikedPlaylists() {
         Playlist playlist = publicPlaylist();
         when(playlistMapper.findLikedByUserId(1L, 20, 10)).thenReturn(List.of(playlist));
@@ -123,7 +133,7 @@ class PlaylistServiceTest {
 
     @Test
     void getPublicPlaylistsRejectsInvalidSearchType() {
-        assertThatThrownBy(() -> playlistService.getPublicPlaylists("", "description", "latest", 0, 20))
+        assertThatThrownBy(() -> playlistService.getPublicPlaylists("", "tag", "latest", 0, 20))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage("검색 타입이 올바르지 않습니다.");
     }


### PR DESCRIPTION
## 요약

- 공개 플레이리스트 검색 타입에 `description`을 추가했습니다.
- 목록 SQL에서 설명 검색 조건을 지원하도록 확장했습니다.
- 홈 화면 검색 대상 선택지에 `설명`을 추가했습니다.
- 검색 타입 정규화 테스트를 보강했습니다.

Closes #47

## 검증

- `./gradlew test`
- `npm run lint`
- `npm run build`
- `git diff --check`