### PR TITLE
[Frontend] 플레이리스트 댓글 수정 UI 추가

### DIFF
--- a/frontend/src/api/playlistApi.js
+++ b/frontend/src/api/playlistApi.js
@@ -166,6 +166,13 @@ export function deletePlaylistComment(commentId) {
   })
 }
 
+export function updatePlaylistComment(commentId, content) {
+  return apiRequest(`/api/comments/${commentId}`, {
+    method: 'PUT',
+    body: JSON.stringify({ content }),
+  })
+}
+
 export function likePlaylist(playlistId) {
   return apiRequest(`/api/playlists/${playlistId}/likes`, {
     method: 'POST',

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -15,6 +15,7 @@ import {
   reorderPlaylistTracks,
   searchSpotifyTracks,
   unlikePlaylist,
+  updatePlaylistComment,
   updatePlaylist as requestPlaylistUpdate,
 } from '../api/playlistApi.js'
 import { Button } from '../components/common/Button.jsx'
@@ -35,6 +36,9 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
   const [actionMessageType, setActionMessageType] = useState('error')
   const [isCommentSubmitting, setIsCommentSubmitting] = useState(false)
   const [deletingCommentId, setDeletingCommentId] = useState(null)
+  const [editingCommentId, setEditingCommentId] = useState(null)
+  const [commentEditContent, setCommentEditContent] = useState('')
+  const [updatingCommentId, setUpdatingCommentId] = useState(null)
   const [hasLiked, setHasLiked] = useState(false)
   const [isLikeSubmitting, setIsLikeSubmitting] = useState(false)
   const [isEditingPlaylist, setIsEditingPlaylist] = useState(false)
@@ -74,6 +78,8 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
       setIsLoading(true)
       setErrorMessage('')
       setCommentContent('')
+      setCommentEditContent('')
+      setEditingCommentId(null)
       clearActionMessage()
       clearTrackMessage()
       setTrackSearchQuery('')
@@ -329,10 +335,51 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
           : currentDetail.playlist,
         comments: currentDetail.comments.filter((comment) => comment.commentId !== commentId),
       }))
+      if (editingCommentId === commentId) {
+        setEditingCommentId(null)
+        setCommentEditContent('')
+      }
     } catch (error) {
       showActionMessage(error.message ?? '댓글을 삭제하지 못했습니다.')
     } finally {
       setDeletingCommentId(null)
+    }
+  }
+
+  function handleCommentEditStart(comment) {
+    setEditingCommentId(comment.commentId)
+    setCommentEditContent(comment.content ?? '')
+    clearActionMessage()
+  }
+
+  function handleCommentEditCancel() {
+    setEditingCommentId(null)
+    setCommentEditContent('')
+  }
+
+  async function handleCommentUpdate(event, commentId) {
+    event.preventDefault()
+    const trimmedEditContent = commentEditContent.trim()
+    if (!trimmedEditContent) {
+      return
+    }
+
+    setUpdatingCommentId(commentId)
+    clearActionMessage()
+
+    try {
+      const updatedComment = await updatePlaylistComment(commentId, trimmedEditContent)
+      setDetail((currentDetail) => ({
+        ...currentDetail,
+        comments: currentDetail.comments.map((comment) => (comment.commentId === commentId ? updatedComment : comment)),
+      }))
+      setEditingCommentId(null)
+      setCommentEditContent('')
+      showActionMessage('댓글을 수정했습니다.', 'success')
+    } catch (error) {
+      showActionMessage(error.message ?? '댓글을 수정하지 못했습니다.')
+    } finally {
+      setUpdatingCommentId(null)
     }
   }
 
@@ -653,10 +700,17 @@ export function PlaylistDetailPage({ currentUser, onBack, onSelectPlaylist, play
                     {comments.map((comment) => (
                       <CommentItem
                         comment={comment}
+                        commentEditContent={commentEditContent}
                         currentUser={currentUser}
                         deletingCommentId={deletingCommentId}
+                        editingCommentId={editingCommentId}
                         key={comment.commentId}
                         onDelete={handleCommentDelete}
+                        onEditCancel={handleCommentEditCancel}
+                        onEditChange={setCommentEditContent}
+                        onEditStart={handleCommentEditStart}
+                        onUpdate={handleCommentUpdate}
+                        updatingCommentId={updatingCommentId}
                       />
                     ))}
                   </div>
@@ -765,24 +819,70 @@ function TrackText({ track }) {
   )
 }
 
-function CommentItem({ comment, currentUser, deletingCommentId, onDelete }) {
+function CommentItem({
+  comment,
+  commentEditContent,
+  currentUser,
+  deletingCommentId,
+  editingCommentId,
+  onDelete,
+  onEditCancel,
+  onEditChange,
+  onEditStart,
+  onUpdate,
+  updatingCommentId,
+}) {
   const isCommentOwner = currentUser?.userId === comment.userId
   const isDeleting = deletingCommentId === comment.commentId
+  const isEditing = editingCommentId === comment.commentId
+  const isUpdating = updatingCommentId === comment.commentId
+  const trimmedEditContent = commentEditContent.trim()
+  const isEditUnchanged = trimmedEditContent === (comment.content ?? '').trim()
 
   return (
     <article className="comment-item">
-      <div>
-        <div>
+      <div className="comment-header">
+        <div className="comment-meta">
           <strong>{comment.userNickname}</strong>
-          <span>{formatDate(comment.createdAt)}</span>
+          <span>
+            {formatDate(comment.createdAt)}
+            {comment.updatedAt ? ` · 수정 ${formatDate(comment.updatedAt)}` : ''}
+          </span>
         </div>
         {isCommentOwner ? (
-          <Button className="button-ghost comment-delete-button" disabled={isDeleting} onClick={() => onDelete(comment.commentId)}>
-            {isDeleting ? '삭제 중' : '삭제'}
-          </Button>
+          <div className="comment-actions">
+            <Button className="button-ghost" disabled={isDeleting || isEditing} onClick={() => onEditStart(comment)}>
+              수정
+            </Button>
+            <Button className="button-ghost" disabled={isDeleting || isUpdating} onClick={() => onDelete(comment.commentId)}>
+              {isDeleting ? '삭제 중' : '삭제'}
+            </Button>
+          </div>
         ) : null}
       </div>
-      <p>{comment.content}</p>
+      {isEditing ? (
+        <form className="comment-edit-form" onSubmit={(event) => onUpdate(event, comment.commentId)}>
+          <textarea
+            maxLength={1000}
+            onChange={(event) => onEditChange(event.target.value)}
+            rows={4}
+            value={commentEditContent}
+          />
+          <div className="comment-form-actions">
+            <span>{commentEditContent.trim().length}/1000</span>
+            <div className="comment-actions">
+              <Button className="button-secondary" disabled={isUpdating} onClick={onEditCancel}>
+                취소
+              </Button>
+              <Button disabled={isUpdating || !trimmedEditContent || isEditUnchanged} type="submit">
+                {isUpdating ? '저장 중' : '저장'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      ) : (
+        <p>{comment.content}</p>
+      )}
     </article>
   )
 }

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -1100,7 +1100,8 @@ a:focus-visible {
   font-weight: 700;
 }
 
-.comment-form textarea {
+.comment-form textarea,
+.comment-edit-form textarea {
   width: 100%;
   min-height: 112px;
   resize: vertical;
@@ -1133,7 +1134,7 @@ a:focus-visible {
   background: var(--color-surface-raised);
 }
 
-.comment-item > div {
+.comment-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -1142,7 +1143,7 @@ a:focus-visible {
   font-size: 13px;
 }
 
-.comment-item > div > div {
+.comment-meta {
   display: grid;
   gap: 4px;
 }
@@ -1157,8 +1158,18 @@ a:focus-visible {
   line-height: 1.6;
 }
 
-.comment-delete-button {
+.comment-actions {
+  display: flex;
   flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.comment-edit-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
 }
 
 .similar-list {


### PR DESCRIPTION
## 요약

- 댓글 수정 API client 함수를 추가했습니다.
- 플레이리스트 상세 댓글 목록에서 작성자 본인 댓글에 수정 버튼을 노출했습니다.
- 댓글 수정 폼, 저장/취소, 저장 중 상태를 추가했습니다.
- 수정 성공 시 댓글 목록의 내용과 수정 시각을 갱신합니다.

Closes #49

## 검증

- `npm run lint`
- `npm run build`
- `git diff --check`