### PR TITLE
[Frontend] 수록곡 Spotify 원본 링크 표시

### DIFF
--- a/frontend/src/pages/PlaylistBuilderPage.jsx
+++ b/frontend/src/pages/PlaylistBuilderPage.jsx
@@ -285,6 +285,11 @@ function TrackText({ track }) {
       <small>
         {track.albumName || '앨범 정보 없음'} · {formatDuration(track.durationMs)}
       </small>
+      {track.spotifyUrl ? (
+        <a className="builder-track-source" href={track.spotifyUrl} rel="noreferrer" target="_blank">
+          Spotify에서 보기
+        </a>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/pages/PlaylistBuilderPage.jsx
+++ b/frontend/src/pages/PlaylistBuilderPage.jsx
@@ -286,7 +286,7 @@ function TrackText({ track }) {
         {track.albumName || '앨범 정보 없음'} · {formatDuration(track.durationMs)}
       </small>
       {track.spotifyUrl ? (
-        <a className="builder-track-source" href={track.spotifyUrl} rel="noreferrer" target="_blank">
+        <a className="builder-track-source" href={track.spotifyUrl} rel="noopener noreferrer" target="_blank">
           Spotify에서 보기
         </a>
       ) : null}

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -871,6 +871,11 @@ function TrackText({ track }) {
     <div className="track-main">
       <strong>{track.title}</strong>
       <span>{track.artistName}</span>
+      {track.spotifyUrl ? (
+        <a className="track-source" href={track.spotifyUrl} rel="noreferrer" target="_blank">
+          Spotify에서 보기
+        </a>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/pages/PlaylistDetailPage.jsx
+++ b/frontend/src/pages/PlaylistDetailPage.jsx
@@ -872,7 +872,7 @@ function TrackText({ track }) {
       <strong>{track.title}</strong>
       <span>{track.artistName}</span>
       {track.spotifyUrl ? (
-        <a className="track-source" href={track.spotifyUrl} rel="noreferrer" target="_blank">
+        <a className="track-source" href={track.spotifyUrl} rel="noopener noreferrer" target="_blank">
           Spotify에서 보기
         </a>
       ) : null}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -675,6 +675,7 @@ a:focus-visible {
 .builder-track-source,
 .track-source {
   width: fit-content;
+  max-width: 100%;
   color: var(--color-accent);
   font-size: 12px;
   font-weight: 700;

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -656,7 +656,8 @@ a:focus-visible {
 
 .builder-track-text strong,
 .builder-track-text span,
-.builder-track-text small {
+.builder-track-text small,
+.builder-track-source {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -669,6 +670,20 @@ a:focus-visible {
 
 .builder-track-text small {
   font-size: 12px;
+}
+
+.builder-track-source,
+.track-source {
+  width: fit-content;
+  color: var(--color-accent);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.builder-track-source:hover,
+.track-source:hover {
+  text-decoration: underline;
 }
 
 .builder-track-actions {
@@ -1069,7 +1084,8 @@ a:focus-visible {
 }
 
 .track-main strong,
-.track-album {
+.track-album,
+.track-source {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## 요약

- 플레이리스트 빌더 검색 결과와 담은 곡에 Spotify 원본 링크를 표시했습니다.
- 플레이리스트 상세 수록곡과 곡 추가 검색 결과에도 Spotify 원본 링크를 표시했습니다.
- `spotifyUrl`이 없는 곡은 링크를 렌더링하지 않습니다.
- 링크 스타일을 곡 메타 영역에 맞춰 추가했습니다.

Closes #53

## 검증

- `npm run lint`
- `npm run build`
- `git diff --check`